### PR TITLE
Docstrings for all remaining entities

### DIFF
--- a/taurus/entity/attribute/base_attribute.py
+++ b/taurus/entity/attribute/base_attribute.py
@@ -30,6 +30,7 @@ class BaseAttribute(DictSerializable):
         Links to files associated with the attribute.
 
     """
+
     attribute_type = None
 
     def __init__(self, name=None, template=None, origin="unknown", value=None, notes=None,

--- a/taurus/entity/attribute/base_attribute.py
+++ b/taurus/entity/attribute/base_attribute.py
@@ -9,8 +9,28 @@ from taurus.entity.link_by_uid import LinkByUID
 
 
 class BaseAttribute(DictSerializable):
-    """Base class for attributes, which include Property, Parameter, Condition, and Metadata."""
+    """
+    Base class for all attributes, which include property, condition, parameter, and metadata.
 
+    Parameters
+    ----------
+    name: str
+        Required name of the attribute. Each attribute within an object must have a unique name.
+    notes: str
+        Optional free-form notes about the attribute.
+    value: :py:class:`BaseValue <taurus.entity.value.base_value.BaseValue>`
+        The value of the attribute.
+    template: :class:`AttributeTemplate \
+    <taurus.entity.template.attribute_template.AttributeTemplate>`
+        Attribute template that defines the allowed bounds of this attribute. If a template
+        and value are both present then the value must be within the template bounds.
+    origin: str
+        The origin of the attribute. Must be one of "measured", "predicted", "summary",
+        "specified", "computed", or "unknown." Default is "unknown."
+    file_links: List[FileLink]
+        Links to files associated with the attribute.
+
+    """
     attribute_type = None
 
     def __init__(self, name=None, template=None, origin="unknown", value=None, notes=None,

--- a/taurus/entity/attribute/base_attribute.py
+++ b/taurus/entity/attribute/base_attribute.py
@@ -1,4 +1,3 @@
-"""Base class for all attributes."""
 from taurus.entity.dict_serializable import DictSerializable
 from taurus.entity.template.attribute_template import AttributeTemplate
 from taurus.entity.value.base_value import BaseValue

--- a/taurus/entity/attribute/condition.py
+++ b/taurus/entity/attribute/condition.py
@@ -4,7 +4,13 @@ from taurus.enumeration import AttributeType
 
 
 class Condition(BaseAttribute):
-    """Condition of a property, process, or measurement."""
+    """
+    Condition of a property, process, or measurement.
+
+    Conditions are environmental variables (typically measured) that may affect a process
+    or measurement: e.g., temperature, pressure.
+
+    """
 
     typ = "condition"
     attribute_type = AttributeType.CONDITION

--- a/taurus/entity/attribute/condition.py
+++ b/taurus/entity/attribute/condition.py
@@ -1,4 +1,3 @@
-"""Condition class."""
 from taurus.entity.attribute.base_attribute import BaseAttribute
 from taurus.enumeration import AttributeType
 

--- a/taurus/entity/attribute/parameter.py
+++ b/taurus/entity/attribute/parameter.py
@@ -1,4 +1,3 @@
-"""Parameter class."""
 from taurus.entity.attribute.base_attribute import BaseAttribute
 from taurus.enumeration import AttributeType
 

--- a/taurus/entity/attribute/parameter.py
+++ b/taurus/entity/attribute/parameter.py
@@ -4,7 +4,14 @@ from taurus.enumeration import AttributeType
 
 
 class Parameter(BaseAttribute):
-    """Parameter of a process or measurement."""
+    """
+    Parameter of a process or measurement.
+
+    Parameters are the non-environmental variables (typically specified and controlled) that may
+    affect a process or measurement: e.g. oven dial temperature for a kiln firing, magnification
+    for a measurement taken with an electron microscope.
+
+    """
 
     typ = "parameter"
     attribute_type = AttributeType.PARAMETER

--- a/taurus/entity/attribute/property.py
+++ b/taurus/entity/attribute/property.py
@@ -1,4 +1,3 @@
-"""Property class."""
 from taurus.entity.attribute.base_attribute import BaseAttribute
 from taurus.enumeration import AttributeType
 

--- a/taurus/entity/attribute/property.py
+++ b/taurus/entity/attribute/property.py
@@ -4,7 +4,13 @@ from taurus.enumeration import AttributeType
 
 
 class Property(BaseAttribute):
-    """Property of a material, measured in a MeasurementRun or specified in a MaterialSpec."""
+    """
+    Property of a material, measured in a MeasurementRun or specified in a MaterialSpec.
+
+    Properties are characteristics of a material that could be measured, e.g. chemical composition,
+     density, yield strength.
+
+    """
 
     typ = "property"
     attribute_type = AttributeType.PROPERTY

--- a/taurus/entity/attribute/property_and_conditions.py
+++ b/taurus/entity/attribute/property_and_conditions.py
@@ -1,4 +1,3 @@
-"""Class for combined property and conditions."""
 from taurus.entity.attribute.condition import Condition
 from taurus.entity.attribute.property import Property
 from taurus.entity.dict_serializable import DictSerializable
@@ -6,7 +5,19 @@ from taurus.entity.setters import validate_list
 
 
 class PropertyAndConditions(DictSerializable):
-    """Property and conditions, as in a measurement spec."""
+    """
+    A property and the conditions under which that property was determined.
+
+    This attribute is only relevant for material specs.
+
+    Parameters
+    ----------
+    property: Property
+        A property attribute
+    conditions: List[Condition]
+        An optional list of conditions associated with this property.
+
+    """
 
     typ = "property_and_conditions"
 

--- a/taurus/entity/base_entity.py
+++ b/taurus/entity/base_entity.py
@@ -15,8 +15,8 @@ class BaseEntity(DictSerializable):
         specification/unique-identifiers/>`_.
     tags: List[str]
         `Tags <https://citrineinformatics.github.io/taurus-documentation/specification/tags/>`_
-        are hierarchical strings that store information about an entity and can be used
-        for discoverability.
+        are hierarchical strings that store information about an entity. They can be used
+        for filtering and discoverability.
 
     """
 

--- a/taurus/entity/file_link.py
+++ b/taurus/entity/file_link.py
@@ -4,9 +4,11 @@ from taurus.entity.dict_serializable import DictSerializable
 
 class FileLink(DictSerializable):
     """
-    `FileLink \
+    FileLink stores a name and link to an external resource.
+
+    More information can be found in the
+    `data model documentation \
     <https://citrineinformatics.github.io/taurus-documentation/specification/file-links/>`_
-    stores a name and link to an external resource.
 
     Once the file protocol is defined, there should be substantial validation.
 

--- a/taurus/entity/file_link.py
+++ b/taurus/entity/file_link.py
@@ -4,7 +4,9 @@ from taurus.entity.dict_serializable import DictSerializable
 
 class FileLink(DictSerializable):
     """
-    Class for storing a name and link to an external resource.
+    `FileLink \
+    <https://citrineinformatics.github.io/taurus-documentation/specification/file-links/>`_
+    stores a name and link to an external resource.
 
     Once the file protocol is defined, there should be substantial validation.
 

--- a/taurus/entity/object/base_object.py
+++ b/taurus/entity/object/base_object.py
@@ -1,4 +1,3 @@
-"""Base class for all Data Concepts objects."""
 from taurus.entity.base_entity import BaseEntity
 from taurus.entity.file_link import FileLink
 from taurus.entity.setters import validate_list, validate_str
@@ -9,6 +8,24 @@ class BaseObject(BaseEntity):
     Base class for objects.
 
     This includes {Material, Process, Measurement, Ingredient} {Run, Spec}
+
+    Parameters
+    ----------
+    name: str, optional
+        Name of the material spec.
+    uids: Map[str, str], optional
+        A collection of
+        `unique IDs <https://citrineinformatics.github.io/taurus-documentation/
+        specification/unique-identifiers/>`_.
+    tags: List[str], optional
+        `Tags <https://citrineinformatics.github.io/taurus-documentation/specification/tags/>`_
+        are hierarchical strings that store information about an entity. They can be used
+        for filtering and discoverability.
+    notes: str, optional
+        Long-form notes about the material spec.
+    file_links: List[FileLink], optional
+        Links to associated files, with resource paths into the files API.
+
     """
 
     def __init__(self, name=None, uids=None, tags=None, notes=None, file_links=None):

--- a/taurus/entity/object/ingredient_run.py
+++ b/taurus/entity/object/ingredient_run.py
@@ -1,4 +1,3 @@
-"""An ingredient run is a material run being used in a process run.."""
 from taurus.entity.object.base_object import BaseObject
 from taurus.entity.object.has_quantities import HasQuantities
 from taurus.entity.setters import validate_list
@@ -6,7 +5,49 @@ from taurus.entity.valid_list import ValidList
 
 
 class IngredientRun(BaseObject, HasQuantities):
-    """An ingredient run, with quantities and link to originating material."""
+    """
+    An ingredient run.
+
+    Ingredients annotate a material with information about its usage in a process.
+
+    Parameters
+    ----------
+    uids: Map[str, str], optional
+        A collection of
+        `unique IDs <https://citrineinformatics.github.io/taurus-documentation/
+        specification/unique-identifiers/>`_.
+    tags: List[str], optional
+        `Tags <https://citrineinformatics.github.io/taurus-documentation/specification/tags/>`_
+        are hierarchical strings that store information about an entity. They can be used
+        for filtering and discoverability.
+    notes: str, optional
+        Long-form notes about the ingredient run.
+    material: MaterialRun
+        Material that this ingredient is.
+    process: ProcessRun
+        Process that this ingredient is used in.
+    mass_fraction: :py:class:`ContinuousValue \
+    <taurus.entity.value.continuous_value.ContinuousValue>`, optional
+        The mass fraction of the ingredient in the process.
+    volume_fraction: :py:class:`ContinuousValue \
+    <taurus.entity.value.continuous_value.ContinuousValue>`, optional
+        The volume fraction of the ingredient in the process.
+    number_fraction: :py:class:`ContinuousValue \
+    <taurus.entity.value.continuous_value.ContinuousValue>`, optional
+        The number fraction of the ingredient in the process.
+    absolute_quantity: :py:class:`ContinuousValue \
+    <taurus.entity.value.continuous_value.ContinuousValue>`, optional
+        The absolute quantity of the ingredient in the process.
+    name: str, optional
+        Label on the ingredient that is unique within the process that contains it.
+    labels: List[str], optional
+        Additional labels on the ingredient that must be unique.
+    spec: IngredientSpec
+        The specification of which this ingredient is a realization.
+    file_links: List[FileLink], optional
+        Links to associated files, with resource paths into the files API.
+
+    """
 
     typ = "ingredient_run"
 
@@ -14,18 +55,6 @@ class IngredientRun(BaseObject, HasQuantities):
                  mass_fraction=None, volume_fraction=None, number_fraction=None,
                  absolute_quantity=None,
                  spec=None, uids=None, tags=None, notes=None, file_links=None):
-        """
-        Create an IngredientRun object.
-
-        Assigns quantities and labels to a material being used in a process
-        :param material: MaterialRun that is being used as the ingredient
-        :param name: of the ingredient as used in the process, e.g. "the peanut butter"
-        :param labels: that this ingredient belongs to, e.g. "spread" or "solvent"
-        :param mass_fraction: fraction of the ingredients that is this input ingredient, by mass
-        :param volume_fraction: fraction of the ingredients that is this ingredient, by volume
-        :param number_fraction: fraction of the ingredients that is this ingredient, by number
-        :param absolute_quantity: quantity of this ingredient in an absolute sense, e.g. 2 cups
-        """
         BaseObject.__init__(self, name, uids, tags, notes=notes, file_links=file_links)
         HasQuantities.__init__(self, mass_fraction, volume_fraction, number_fraction,
                                absolute_quantity)

--- a/taurus/entity/object/ingredient_spec.py
+++ b/taurus/entity/object/ingredient_spec.py
@@ -1,4 +1,3 @@
-"""An ingredient spec is the intent of a material being used in a process."""
 from taurus.entity.object.base_object import BaseObject
 from taurus.entity.object.has_quantities import HasQuantities
 from taurus.entity.setters import validate_list
@@ -6,7 +5,47 @@ from taurus.entity.valid_list import ValidList
 
 
 class IngredientSpec(BaseObject, HasQuantities):
-    """Ingredient spec, with quantities and links to originating material."""
+    """
+    An ingredient specification.
+
+    Ingredients annotate a material with information about its usage in a process.
+
+    Parameters
+    ----------
+    uids: Map[str, str], optional
+        A collection of
+        `unique IDs <https://citrineinformatics.github.io/taurus-documentation/
+        specification/unique-identifiers/>`_.
+    tags: List[str], optional
+        `Tags <https://citrineinformatics.github.io/taurus-documentation/specification/tags/>`_
+        are hierarchical strings that store information about an entity. They can be used
+        for filtering and discoverability.
+    notes: str, optional
+        Long-form notes about the ingredient spec.
+    material: MaterialSpec
+        Material that this ingredient is.
+    process: ProcessSpec
+        Process that this ingredient is used in.
+    mass_fraction: :py:class:`ContinuousValue \
+    <taurus.entity.value.continuous_value.ContinuousValue>`, optional
+        The mass fraction of the ingredient in the process.
+    volume_fraction: :py:class:`ContinuousValue \
+    <taurus.entity.value.continuous_value.ContinuousValue>`, optional
+        The volume fraction of the ingredient in the process.
+    number_fraction: :py:class:`ContinuousValue \
+    <taurus.entity.value.continuous_value.ContinuousValue>`, optional
+        The number fraction of the ingredient in the process.
+    absolute_quantity: :py:class:`ContinuousValue \
+    <taurus.entity.value.continuous_value.ContinuousValue>`, optional
+        The absolute quantity of the ingredient in the process.
+    name: str, optional
+        Label on the ingredient that is unique within the process that contains it.
+    labels: List[str], optional
+        Additional labels on the ingredient that must be unique.
+    file_links: List[FileLink], optional
+        Links to associated files, with resource paths into the files API.
+
+    """
 
     typ = "ingredient_spec"
 

--- a/taurus/entity/object/material_run.py
+++ b/taurus/entity/object/material_run.py
@@ -1,11 +1,44 @@
-"""A material run."""
 from taurus.entity.object.base_object import BaseObject
 from taurus.enumeration import SampleType
 
 
 class MaterialRun(BaseObject):
-    """Realization of a Material, with links to its spec, originating process, and measurements."""
+    """
+    A material run.
 
+    This includes a link to the originating process and soft links to measurements.
+
+    Parameters
+    ----------
+    name: str, optional
+        Name of the material run.
+    uids: Map[str, str], optional
+        A collection of
+        `unique IDs <https://citrineinformatics.github.io/taurus-documentation/
+        specification/unique-identifiers/>`_.
+    tags: List[str], optional
+        `Tags <https://citrineinformatics.github.io/taurus-documentation/specification/tags/>`_
+        are hierarchical strings that store information about an entity. They can be used
+        for filtering and discoverability.
+    notes: str, optional
+        Long-form notes about the material run.
+    process: ProcessRun
+        Process that produces this material.
+    sample_type: str, optional
+        The form of this sample. Optionals are "experimental", "virtual", "production", or
+        "unknown." Default is "unknown."
+    spec: MaterialSpec
+        The material specification of which this is an instance.
+    file_links: List[FileLink], optional
+        Links to associated files, with resource paths into the files API.
+
+    Attributes
+    ----------
+    measurements: List[MeasurementRun], optional
+        Measurements performed on this material. The link is established by creating the
+        measurement run and settings its `material` field to this material run.
+
+    """
     typ = "material_run"
 
     skip = {"_measurements"}

--- a/taurus/entity/object/material_run.py
+++ b/taurus/entity/object/material_run.py
@@ -39,6 +39,7 @@ class MaterialRun(BaseObject):
         measurement run and settings its `material` field to this material run.
 
     """
+
     typ = "material_run"
 
     skip = {"_measurements"}

--- a/taurus/entity/object/material_spec.py
+++ b/taurus/entity/object/material_spec.py
@@ -1,4 +1,3 @@
-"""A material spec."""
 from taurus.entity.attribute.property_and_conditions import PropertyAndConditions
 from taurus.entity.object.base_object import BaseObject
 from taurus.entity.object.has_template import HasTemplate
@@ -7,9 +6,34 @@ from taurus.entity.setters import validate_list
 
 class MaterialSpec(BaseObject, HasTemplate):
     """
-    Specification of the intent of a material.
+    A material specification.
 
-    This includes links to originating process and specified properties
+    This includes a link to the originating process and specified properties with conditions.
+
+    Parameters
+    ----------
+    name: str, optional
+        Name of the material spec.
+    uids: Map[str, str], optional
+        A collection of
+        `unique IDs <https://citrineinformatics.github.io/taurus-documentation/
+        specification/unique-identifiers/>`_.
+    tags: List[str], optional
+        `Tags <https://citrineinformatics.github.io/taurus-documentation/specification/tags/>`_
+        are hierarchical strings that store information about an entity. They can be used
+        for filtering and discoverability.
+    notes: str, optional
+        Long-form notes about the material spec.
+    process: ProcessSpec
+        Process that produces this material.
+    properties: List[PropertyAndConditions], optional
+        Properties of the material, along with an optional list of conditions under which
+        those properties are measured.
+    template: MaterialTemplate, optional
+        A template bounding the valid values for this material's properties.
+    file_links: List[FileLink], optional
+        Links to associated files, with resource paths into the files API.
+
     """
 
     typ = "material_spec"

--- a/taurus/entity/object/measurement_run.py
+++ b/taurus/entity/object/measurement_run.py
@@ -1,4 +1,3 @@
-"""A measurement run performed on a material."""
 from taurus.entity.object.base_object import BaseObject
 from taurus.entity.object.has_conditions import HasConditions
 from taurus.entity.object.has_properties import HasProperties
@@ -9,9 +8,40 @@ from taurus.entity.valid_list import ValidList
 
 class MeasurementRun(BaseObject, HasConditions, HasProperties, HasParameters):
     """
-    Realization of a measurement, which includes measured conditions, properties, and parameters.
+    A measurement run.
 
-    MeasurementRun includes a soft-link to the MaterialRun that contains it, if any.
+    This contains a link to the material the measurement is performed on, as well as links to
+    any properties, conditions, and parameters.
+
+    Parameters
+    ----------
+    name: str, optional
+        Name of the measurement run.
+    uids: Map[str, str], optional
+        A collection of
+        `unique IDs <https://citrineinformatics.github.io/taurus-documentation/
+        specification/unique-identifiers/>`_.
+    tags: List[str], optional
+        `Tags <https://citrineinformatics.github.io/taurus-documentation/specification/tags/>`_
+        are hierarchical strings that store information about an entity. They can be used
+        for filtering and discoverability.
+    notes: str, optional
+        Long-form notes about the measurement run.
+    conditions: List[Condition], optional
+        Conditions under which this measurement run occurs.
+    parameters: List[Parameter], optional
+        Parameters of this measurement run.
+    properties: List[Property], optional
+        Properties that are measured during this measurement run.
+    spec: MeasurementSpec
+        The measurement specification of which this is an instance.
+    material: MaterialRun
+        The material run being measured.
+    spec: MaterialSpec
+        The material specification of which this is an instance.
+    file_links: List[FileLink], optional
+        Links to associated files, with resource paths into the files API.
+
     """
 
     typ = "measurement_run"

--- a/taurus/entity/object/measurement_spec.py
+++ b/taurus/entity/object/measurement_spec.py
@@ -1,4 +1,3 @@
-"""A measurement spec."""
 from taurus.entity.object.base_object import BaseObject
 from taurus.entity.object.has_parameters import HasParameters
 from taurus.entity.object.has_conditions import HasConditions
@@ -6,7 +5,37 @@ from taurus.entity.object.has_template import HasTemplate
 
 
 class MeasurementSpec(BaseObject, HasParameters, HasConditions, HasTemplate):
-    """Specification of a measurement, including the relevant conditions and parameters."""
+    """
+    A measurement specification.
+
+    This includes links to the conditions and parameters under which the measurement is
+    expected to be performed.
+
+    Parameters
+    ----------
+    name: str, optional
+        Name of the measurement spec.
+    uids: Map[str, str], optional
+        A collection of
+        `unique IDs <https://citrineinformatics.github.io/taurus-documentation/
+        specification/unique-identifiers/>`_.
+    tags: List[str], optional
+        `Tags <https://citrineinformatics.github.io/taurus-documentation/specification/tags/>`_
+        are hierarchical strings that store information about an entity. They can be used
+        for filtering and discoverability.
+    notes: str, optional
+        Long-form notes about the measurement spec.
+    conditions: List[Condition], optional
+        Conditions under which this measurement spec occurs.
+    parameters: List[Parameter], optional
+        Parameters of this measurement spec.
+    template: MeasurementTemplate
+        A template bounding the valid values for the measurement's properties, parameters,
+        and conditions.
+    file_links: List[FileLink], optional
+        Links to associated files, with resource paths into the files API.
+
+    """
 
     typ = "measurement_spec"
 

--- a/taurus/entity/object/process_run.py
+++ b/taurus/entity/object/process_run.py
@@ -1,4 +1,3 @@
-"""A process run, which turns into ingredients into a material."""
 from taurus.entity.object.base_object import BaseObject
 from taurus.entity.object.has_conditions import HasConditions
 from taurus.entity.object.has_parameters import HasParameters
@@ -6,10 +5,45 @@ from taurus.entity.object.has_parameters import HasParameters
 
 class ProcessRun(BaseObject, HasConditions, HasParameters):
     """
-    Realization of a process.
+    A process run.
 
-    This includes links to the input materials and measured conditions and parameters
-    ProcessRun includes a soft-link to the MaterialRun that it produces, if any
+    Processes transform zero or more input materials into exactly one output material.
+    This includes links to conditions and parameters under which the process was performed,
+    as well as soft links to the output material and each of the input ingredients.
+
+    Parameters
+    ----------
+    name: str, optional
+        Name of the process run.
+    uids: Map[str, str], optional
+        A collection of
+        `unique IDs <https://citrineinformatics.github.io/taurus-documentation/
+        specification/unique-identifiers/>`_.
+    tags: List[str], optional
+        `Tags <https://citrineinformatics.github.io/taurus-documentation/specification/tags/>`_
+        are hierarchical strings that store information about an entity. They can be used
+        for filtering and discoverability.
+    notes: str, optional
+        Long-form notes about the process run.
+    conditions: List[Condition], optional
+        Conditions under which this process run occurs.
+    parameters: List[Parameter], optional
+        Parameters of this process run.
+    spec: ProcessSpec
+        Spec for this process run.
+    file_links: List[FileLink], optional
+        Links to associated files, with resource paths into the files API.
+
+    Attributes
+    ----------
+    output_material: MaterialRun
+        The material run that this process run produces. The link is established by creating
+        the material run and settings its `process` field to this process run.
+
+    ingredients: List[IngredientRun]
+        Ingredient runs that act as inputs to this process run. The link is established by
+        creating each ingredient run and setting its `process` field to this process run.
+
     """
 
     typ = "process_run"

--- a/taurus/entity/object/process_spec.py
+++ b/taurus/entity/object/process_spec.py
@@ -1,4 +1,3 @@
-"""A process spec, the intent of a process that converts ingredients into an intended material."""
 from taurus.entity.object.base_object import BaseObject
 from taurus.entity.object.has_parameters import HasParameters
 from taurus.entity.object.has_conditions import HasConditions
@@ -7,10 +6,45 @@ from taurus.entity.object.has_template import HasTemplate
 
 class ProcessSpec(BaseObject, HasParameters, HasConditions, HasTemplate):
     """
-    Specification of a process.
+    A process specification.
 
-    This includes a link to the input material specs and relevant conditions and parameters
-    ProcessSpec includes a soft-link to the MaterialSpec that it produces, if any
+    Processes transform zero or more input materials into exactly one output material.
+    This includes links to the parameters and conditions under which the process is expected
+    to be performed, as well as soft links to the output material and the input ingredients.
+
+    Parameters
+    ----------
+    name: str, optional
+        Name of the process spec.
+    uids: Map[str, str], optional
+        A collection of
+        `unique IDs <https://citrineinformatics.github.io/taurus-documentation/
+        specification/unique-identifiers/>`_.
+    tags: List[str], optional
+        `Tags <https://citrineinformatics.github.io/taurus-documentation/specification/tags/>`_
+        are hierarchical strings that store information about an entity. They can be used
+        for filtering and discoverability.
+    notes: str, optional
+        Long-form notes about the process spec.
+    conditions: List[Condition], optional
+        Conditions under which this process spec occurs.
+    parameters: List[Parameter], optional
+        Parameters of this process spec.
+    template: ProcessTemplate, optional
+        A template bounding the valid values for this process's parameters and conditions.
+    file_links: List[FileLink], optional
+        Links to associated files, with resource paths into the files API.
+
+    Attributes
+    ----------
+    output_material: MaterialSpec
+        The material spec that this process spec produces. The link is established by creating
+        the material spec and settings its `process` field to this process spec.
+
+    ingredients: List[IngredientSpec], optional
+        Ingredient specs that act as inputs to this process spec. The link is established by
+        creating each ingredient spec and setting its `process` field to this process spec.
+
     """
 
     typ = "process_spec"

--- a/taurus/entity/template/attribute_template.py
+++ b/taurus/entity/template/attribute_template.py
@@ -26,8 +26,6 @@ class AttributeTemplate(BaseEntity):
 
     """
 
-    skip = ["_data_type"]
-
     def __init__(self, name=None, description=None, bounds=None, uids=None, tags=None):
         BaseEntity.__init__(self, uids, tags)
         self.name = name

--- a/taurus/entity/template/attribute_template.py
+++ b/taurus/entity/template/attribute_template.py
@@ -5,23 +5,30 @@ from taurus.entity.bounds.base_bounds import BaseBounds
 
 class AttributeTemplate(BaseEntity):
     """
-    Class for all attribute templates, which must contain a bounds and scope.
+    An attribute template, which can be a property, parameter, or condition template.
 
-    The bounds implies the type of the template, e.g. RealBounds imply data_type = DataType.REAL.
+    Parameters
+    ----------
+    name: str
+        The name of the attribute template.
+    bounds: :py:class:`BaseBounds <taurus.entity.bounds.base_bounds.BaseBounds>`
+        Bounds circumscribe the values that are valid according to this attribute template.
+    description: str, optional
+        A long-form description of the attribute template.
+    uids: Map[str, str], optional
+        A collection of
+        `unique IDs <https://citrineinformatics.github.io/taurus-documentation/
+        specification/unique-identifiers/>`_.
+    tags: List[str], optional
+        `Tags <https://citrineinformatics.github.io/taurus-documentation/specification/tags/>`_
+        are hierarchical strings that store information about an entity. They can be used
+        for filtering and discoverability.
+
     """
 
     skip = ["_data_type"]
 
     def __init__(self, name=None, description=None, bounds=None, uids=None, tags=None):
-        """
-        Create an attribute template.
-
-        :param name: of the template and attributes that it describes
-        :param description: of the attribute that the template describes
-        :param bounds: bounds for data type
-        :param uids: from BaseEntity
-        :param tags: from BaseEntity
-        """
         BaseEntity.__init__(self, uids, tags)
         self.name = name
         self.description = description

--- a/taurus/entity/template/base_template.py
+++ b/taurus/entity/template/base_template.py
@@ -6,7 +6,25 @@ from taurus.entity.template.attribute_template import AttributeTemplate
 
 
 class BaseTemplate(BaseEntity):
-    """Base class for all templates."""
+    """
+    Base class for all object templates.
+
+    Parameters
+    ----------
+    name: str, optional
+        The name of the object template.
+    description: str, optional
+        Long-form description of the object template.
+    uids: Map[str, str], optional
+        A collection of
+        `unique IDs <https://citrineinformatics.github.io/taurus-documentation/
+        specification/unique-identifiers/>`_.
+    tags: List[str], optional
+        `Tags <https://citrineinformatics.github.io/taurus-documentation/specification/tags/>`_
+        are hierarchical strings that store information about an entity. They can be used
+        for filtering and discoverability.
+
+    """
 
     def __init__(self, name=None, description=None, uids=None, tags=None):
         BaseEntity.__init__(self, uids, tags)
@@ -20,7 +38,25 @@ class BaseTemplate(BaseEntity):
 
     @staticmethod
     def _homogenize_ranges(template_or_tuple):
-        """Take either a template or pair and turn it into a (template, bounds) pair."""
+        """
+        Take either a template or pair and turn it into a (template, bounds) pair.
+
+        If no bounds are provided, use the attribute template's default bounds.
+
+        Parameters
+        ----------
+        template_or_tuple: AttributeTemplate OR a list or
+        tuple [AttributeTemplate or LinkByUID, BaseBounds]
+           An attribute template, optionally with another Bounds object that is more
+           restrictive than the attribute template's default bounds.
+
+        Returns
+        -------
+        List[AttributeTemplate or LinkByUID, BaseBounds]
+            The attribute template and bounds that should be applied the the attribute
+            when used in the context of **this** object.
+
+        """
         # if given a template, pull out its bounds
         if isinstance(template_or_tuple, AttributeTemplate):
             return [template_or_tuple, template_or_tuple.bounds]

--- a/taurus/entity/template/condition_template.py
+++ b/taurus/entity/template/condition_template.py
@@ -1,4 +1,3 @@
-"""Condition template."""
 from taurus.entity.template.attribute_template import AttributeTemplate
 
 

--- a/taurus/entity/template/has_condition_templates.py
+++ b/taurus/entity/template/has_condition_templates.py
@@ -5,7 +5,15 @@ from taurus.entity.template.condition_template import ConditionTemplate
 
 
 class HasConditionTemplates(object):
-    """Mixin-trait for entities that include condition template."""
+    """
+    Mixin-trait for entities that include condition templates.
+
+    Parameters
+    ----------
+    conditions: List[ConditionTemplate]
+        A list of this entity's condition templates.
+
+    """
 
     def __init__(self, conditions):
         self._conditions = None
@@ -13,7 +21,15 @@ class HasConditionTemplates(object):
 
     @property
     def conditions(self):
-        """Get the list of condition templates."""
+        """
+        Get the list of condition templates.
+
+        Returns
+        -------
+        List[ConditionTemplate]
+            List of this entity's condition templates
+
+        """
         return self._conditions
 
     @conditions.setter

--- a/taurus/entity/template/has_parameter_templates.py
+++ b/taurus/entity/template/has_parameter_templates.py
@@ -5,7 +5,15 @@ from taurus.entity.template.parameter_template import ParameterTemplate
 
 
 class HasParameterTemplates(object):
-    """Mixin-trait for entities that include parameter templates."""
+    """
+    Mixin-trait for entities that include parameter templates.
+
+    Parameters
+    ----------
+    parameters: List[ParameterTemplate]
+        A list of this entity's parameter templates.
+
+    """
 
     def __init__(self, parameters):
         self._parameters = None
@@ -13,7 +21,15 @@ class HasParameterTemplates(object):
 
     @property
     def parameters(self):
-        """Get the list of parameter templates."""
+        """
+        Get the list of parameter templates.
+
+        Returns
+        -------
+        List[ParameterTemplate]
+            List of this entity's parameter templates
+
+        """
         return self._parameters
 
     @parameters.setter

--- a/taurus/entity/template/has_property_templates.py
+++ b/taurus/entity/template/has_property_templates.py
@@ -5,7 +5,15 @@ from taurus.entity.template.property_template import PropertyTemplate
 
 
 class HasPropertyTemplates(object):
-    """Mixin-trait for entities that include property templates."""
+    """
+    Mixin-trait for entities that include property templates.
+
+    Parameters
+    ----------
+    properties: List[PropertyTemplate]
+        A list of this entity's property templates.
+
+    """
 
     def __init__(self, properties):
         self._properties = None
@@ -13,7 +21,15 @@ class HasPropertyTemplates(object):
 
     @property
     def properties(self):
-        """Get the list of property templates."""
+        """
+        Get the list of property templates.
+
+        Returns
+        -------
+        List[PropertyTemplate]
+            List of this entity's property templates
+
+        """
         return self._properties
 
     @properties.setter

--- a/taurus/entity/template/material_template.py
+++ b/taurus/entity/template/material_template.py
@@ -6,7 +6,36 @@ from taurus.entity.template.has_property_templates import HasPropertyTemplates
 
 
 class MaterialTemplate(BaseTemplate, HasPropertyTemplates):
-    """Template for Materials: MaterialSpec and MaterialRun, containing property templates."""
+    """
+    A material template.
+
+    Material templates are collections of property templates that constrain the values of
+    a material's property attributes, and provide a common structure for describing similar
+    materials.
+
+    Parameters
+    ----------
+    name: str, optional
+        The name of the material template.
+    description: str, optional
+        Long-form description of the material template.
+    uids: Map[str, str], optional
+        A collection of
+        `unique IDs <https://citrineinformatics.github.io/taurus-documentation/
+        specification/unique-identifiers/>`_.
+    tags: List[str], optional
+        `Tags <https://citrineinformatics.github.io/taurus-documentation/specification/tags/>`_
+        are hierarchical strings that store information about an entity. They can be used
+        for filtering and discoverability.
+    properties: List[:class:`PropertyTemplate \
+    <taurus.entity.template.property_template.PropertyTemplate>`] or \
+    List[:class:`PropertyTemplate <taurus.entity.template.property_template.PropertyTemplate>`,\
+     :py:class:`BaseBounds <taurus.entity.bounds.base_bounds.BaseBounds>`], optional
+        Templates for associated properties. Each template can be provided by itself, or as a list
+        with the second entry being a separate, *more restrictive* Bounds object that defines
+        the limits of the value for this property.
+
+    """
 
     typ = "material_template"
 

--- a/taurus/entity/template/measurement_template.py
+++ b/taurus/entity/template/measurement_template.py
@@ -9,7 +9,50 @@ from taurus.entity.template.has_property_templates import HasPropertyTemplates
 
 class MeasurementTemplate(BaseTemplate,
                           HasPropertyTemplates, HasConditionTemplates, HasParameterTemplates):
-    """Template for measurements, containing property, parameter, and condition templates."""
+    """
+    A measurement template.
+
+    Measurement templates are collections of condition, parameter and property templates that
+    constrain the values of a measurement's condition, parameter and property attributes, and
+    provide a common structure for describing similar measurements.
+
+    Parameters
+    ----------
+    name: str, optional
+        The name of the measurement template.
+    description: str, optional
+        Long-form description of the measurement template.
+    uids: Map[str, str], optional
+        A collection of
+        `unique IDs <https://citrineinformatics.github.io/taurus-documentation/
+        specification/unique-identifiers/>`_.
+    tags: List[str], optional
+        `Tags <https://citrineinformatics.github.io/taurus-documentation/specification/tags/>`_
+        are hierarchical strings that store information about an entity. They can be used
+        for filtering and discoverability.
+    conditions: List[:class:`ConditionTemplate \
+    <taurus.entity.template.condition_template.ConditionTemplate>`] or \
+    List[:class:`ConditionTemplate <taurus.entity.template.condition_template.ConditionTemplate>`,\
+     :py:class:`BaseBounds <taurus.entity.bounds.base_bounds.BaseBounds>`], optional
+        Templates for associated conditions. Each template can be provided by itself, or as a list
+        with the second entry being a separate, *more restrictive* Bounds object that defines
+        the limits of the value for this condition.
+    parameters: List[:class:`ParameterTemplate \
+    <taurus.entity.template.parameter_template.ParameterTemplate>`] or \
+    List[:class:`ParameterTemplate <taurus.entity.template.parameter_template.ParameterTemplate>`,\
+     :py:class:`BaseBounds <taurus.entity.bounds.base_bounds.BaseBounds>`], optional
+        Templates for associated parameters. Each template can be provided by itself, or as a list
+        with the second entry being a separate, *more restrictive* Bounds object that defines
+        the limits of the value for this parameter.
+    properties: List[:class:`PropertyTemplate \
+    <taurus.entity.template.property_template.PropertyTemplate>`] or \
+    List[:class:`PropertyTemplate <taurus.entity.template.property_template.PropertyTemplate>`,\
+     :py:class:`BaseBounds <taurus.entity.bounds.base_bounds.BaseBounds>`], optional
+        Templates for associated properties. Each template can be provided by itself, or as a list
+        with the second entry being a separate, *more restrictive* Bounds object that defines
+        the limits of the value for this property.
+
+    """
 
     typ = "measurement_template"
 

--- a/taurus/entity/template/parameter_template.py
+++ b/taurus/entity/template/parameter_template.py
@@ -1,4 +1,3 @@
-"""Parameter template."""
 from taurus.entity.template.attribute_template import AttributeTemplate
 
 

--- a/taurus/entity/template/process_template.py
+++ b/taurus/entity/template/process_template.py
@@ -8,7 +8,43 @@ from taurus.entity.template.has_parameter_templates import HasParameterTemplates
 
 
 class ProcessTemplate(BaseTemplate, HasConditionTemplates, HasParameterTemplates):
-    """Template for processes, containing parameter, and condition templates and ranges."""
+    """
+    A process template.
+
+    Process templates are collections of condition and parameter templates that constrain the
+    values of a measurement's condition and parameter attributes, and provide a common structure
+    for describing similar measurements.
+
+    Parameters
+    ----------
+    name: str, optional
+        The name of the process template.
+    description: str, optional
+        Long-form description of the process template.
+    uids: Map[str, str], optional
+        A collection of
+        `unique IDs <https://citrineinformatics.github.io/taurus-documentation/
+        specification/unique-identifiers/>`_.
+    tags: List[str], optional
+        `Tags <https://citrineinformatics.github.io/taurus-documentation/specification/tags/>`_
+        are hierarchical strings that store information about an entity. They can be used
+        for filtering and discoverability.
+    conditions: List[:class:`ConditionTemplate \
+    <taurus.entity.template.condition_template.ConditionTemplate>`] or \
+    List[:class:`ConditionTemplate <taurus.entity.template.condition_template.ConditionTemplate>`,\
+     :py:class:`BaseBounds <taurus.entity.bounds.base_bounds.BaseBounds>`], optional
+        Templates for associated conditions. Each template can be provided by itself, or as a list
+        with the second entry being a separate, *more restrictive* Bounds object that defines
+        the limits of the value for this condition.
+    parameters: List[:class:`ParameterTemplate \
+    <taurus.entity.template.parameter_template.ParameterTemplate>`] or \
+    List[:class:`ParameterTemplate <taurus.entity.template.parameter_template.ParameterTemplate>`,\
+     :py:class:`BaseBounds <taurus.entity.bounds.base_bounds.BaseBounds>`], optional
+        Templates for associated parameters. Each template can be provided by itself, or as a list
+        with the second entry being a separate, *more restrictive* Bounds object that defines
+        the limits of the value for this parameter.
+
+    """
 
     typ = "process_template"
 

--- a/taurus/entity/template/property_template.py
+++ b/taurus/entity/template/property_template.py
@@ -1,4 +1,3 @@
-"""Property template."""
 from taurus.entity.template.attribute_template import AttributeTemplate
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,8 @@ max-doc-length = 119
 # D104: Docstring in package is often redundant
 # D105: Magic methods (e.g. __str__) are self explanatory
 # D107: __init__ is self explanatory
+# D301: backslash is used in making docstrings for sphinx to parse
 # D401: Imperative mood requirement basically gets in the way
 # E221: When stripping hints for python 3.5 compliance, an extra space is left before operators
-ignore = D100,D104,D105,D107,D401,E221
+ignore = D100,D104,D105,D107,D301,D401,E221
 


### PR DESCRIPTION
Specs, runs, templates, and attributes. 

I did not document some of the validation methods, because they are likely to be removed in #16 