### PR TITLE
Down-select the units supported in pint.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,12 @@ setup(name='taurus',
       author='Max Hutchinson',
       author_email='maxhutch@citrine.io',
       packages=find_packages(),
-      package_data={'taurus': ['demo/strehlow_and_cook.json']},
+      package_data={
+          'taurus': [
+              'demo/strehlow_and_cook.json',
+              'units/citrine_en.txt'
+          ]
+      },
       install_requires=[
           "toolz",
           "pytest>=4.3",

--- a/taurus/entity/attribute/base_attribute.py
+++ b/taurus/entity/attribute/base_attribute.py
@@ -84,7 +84,7 @@ class BaseAttribute(DictSerializable):
             self._template = template
         elif isinstance(template, AttributeTemplate):
             if not template.validate(self):
-                raise ValueError("Template is incompatible with the attribute")
+                raise ValueError("Template is incompatible with attr {}".format(self.name))
             if self.value and not template.bounds.validate(self.value):
                 raise ValueError("the template is inconsistent with the value")
             self._template = template

--- a/taurus/entity/bounds/tests/test_real_bounds.py
+++ b/taurus/entity/bounds/tests/test_real_bounds.py
@@ -31,8 +31,8 @@ def test_boundsless():
 
 def test_non_prefix():
     """Make sure validation works when the units differ by more than a prefix."""
-    dim2 = RealBounds(lower_bound=0, upper_bound=100, default_units="amp")
-    assert dim2.validate(NominalReal(50, "V / ohm"))
+    dim2 = RealBounds(lower_bound=0, upper_bound=100, default_units="N")
+    assert dim2.validate(NominalReal(50, "kg m / sec^2"))
 
 
 def test_contains():

--- a/taurus/ingest/material_run_example.py
+++ b/taurus/ingest/material_run_example.py
@@ -20,7 +20,7 @@ known_properties = {
     ),
     "kinematic viscosity": PropertyTemplate(
         name="kinematic viscosity",
-        bounds=RealBounds(lower_bound=0.0, upper_bound=10.0**40, default_units="m^2/s")
+        bounds=RealBounds(lower_bound=0.0, upper_bound=10.0**40, default_units="")
     )
 }
 
@@ -52,6 +52,7 @@ def _parse_value(val):
         try:
             unit = units.parse_units(toks[-1])
         except (ValueError, units.UndefinedUnitError):
+            print("Couldn't find {}".format(toks[-1]))
             unit = ''
 
         if std >= 0:

--- a/taurus/ingest/material_run_example.py
+++ b/taurus/ingest/material_run_example.py
@@ -16,18 +16,18 @@ from taurus.entity.value.normal_real import NormalReal
 known_properties = {
     "density": PropertyTemplate(
         name="density",
-        bounds=RealBounds(lower_bound=0.0, upper_bound=1000.0, default_units='')
+        bounds=RealBounds(lower_bound=0.0, upper_bound=1000.0, default_units='g / cm^3')
     ),
     "kinematic viscosity": PropertyTemplate(
         name="kinematic viscosity",
-        bounds=RealBounds(lower_bound=0.0, upper_bound=10.0**40, default_units="")
+        bounds=RealBounds(lower_bound=0.0, upper_bound=10.0**40, default_units="m^2 / s")
     )
 }
 
 known_conditions = {
     "temperature": ConditionTemplate(
         name="temperature",
-        bounds=RealBounds(lower_bound=0.0, upper_bound=1000.0, default_units='')
+        bounds=RealBounds(lower_bound=0.0, upper_bound=1000.0, default_units='K')
     )
 }
 

--- a/taurus/ingest/tests/test_material_run_example.py
+++ b/taurus/ingest/tests/test_material_run_example.py
@@ -10,32 +10,32 @@ example = {
     "experiments": [
         {
             "knob_2_setting": "low",
-            "temperature": 300,
-            "density": "1.0 +- 0.5",
+            "temperature": "300 degF",
+            "density": "1.0 +- 0.5 g/cm^3",
             "tags": "warm up"
         },
         {
             "knob_2_setting": "low",
-            "temperature": 302,
-            "density": "1.04 +- 0.1",
+            "temperature": "302 degF",
+            "density": "1.04 +- 0.1 g/cm^3",
             "tags": ["high quality", "hutch"]
         },
         {
             "knob_2_setting": "medium",
-            "density": "0.9 +- 0.4",
+            "density": "0.9 +- 0.4 g/cm^3",
             "tags": ["oops"]
         },
         {
             "knob_2_setting": "medium",
-            "temperature": 456,
-            "density": "0.87 +- 0.1",
+            "temperature": "456 degF",
+            "density": "0.87 +- 0.1 g/cm^3",
             "tags": ["high quality", "hutch"]
         },
         {
             "knob_2_setting": "high",
-            "temperature": 624,
-            "density": "0.80 +- 0.12",
-            "kinematic viscosity": "0.1",
+            "temperature": "624 degF",
+            "density": "0.80 +- 0.12 g/cm^3",
+            "kinematic viscosity": "0.1 m^2/s",
             "tags": ["hutch", "viscous"]
         }
     ]

--- a/taurus/ingest/tests/test_material_run_example.py
+++ b/taurus/ingest/tests/test_material_run_example.py
@@ -35,7 +35,7 @@ example = {
             "knob_2_setting": "high",
             "temperature": 624,
             "density": "0.80 +- 0.12",
-            "kinematic viscosity": "1.0e3 St",
+            "kinematic viscosity": "0.1",
             "tags": ["hutch", "viscous"]
         }
     ]

--- a/taurus/units/citrine_en.txt
+++ b/taurus/units/citrine_en.txt
@@ -1,0 +1,139 @@
+# Citrine down-selected units support
+# Based on `default_en.txt` from Pint
+# https://raw.githubusercontent.com/hgrecco/pint/master/pint/default_en.txt
+
+@defaults
+    group = international
+    system = mks
+@end
+
+#### PREFIXES ####
+
+# decimal prefixes
+yocto- = 1e-24 = y-
+zepto- = 1e-21 = z-
+atto- =  1e-18 = a-
+femto- = 1e-15 = f-
+pico- =  1e-12 = p-
+nano- =  1e-9  = n-
+micro- = 1e-6  = µ- = u-
+milli- = 1e-3  = m-
+centi- = 1e-2  = c-
+deci- =  1e-1  = d-
+deca- =  1e+1  = da- = deka-
+hecto- = 1e2   = h-
+kilo- =  1e3   = k-
+mega- =  1e6   = M-
+giga- =  1e9   = G-
+tera- =  1e12  = T-
+peta- =  1e15  = P-
+exa- =   1e18  = E-
+zetta- = 1e21  = Z-
+yotta- = 1e24  = Y-
+
+# binary_prefixes
+kibi- = 2**10 = Ki-
+mebi- = 2**20 = Mi-
+gibi- = 2**30 = Gi-
+tebi- = 2**40 = Ti-
+pebi- = 2**50 = Pi-
+exbi- = 2**60 = Ei-
+zebi- = 2**70 = Zi-
+yobi- = 2**80 = Yi-
+
+#### BASE UNITS ####
+
+meter = [length] = m = metre
+second = [time] = s = sec
+gram = [mass] = g
+kelvin = [temperature]; offset: 0 = K = degK = °K = degree_Kelvin = degreeK  # older names supported for compatibility
+
+#### UNITS ####
+
+# Mass
+metric_ton = 1e3 * kilogram = t = tonne
+
+# Time
+minute = 60 * second = min
+hour = 60 * minute = hr
+day = 24 * hour = d
+
+# Temperature
+degree_Celsius = kelvin; offset: 273.15 = °C = celsius = degC = degreeC
+degree_Fahrenheit = 5 / 9 * kelvin; offset: 233.15 + 200 / 9 = °F = fahrenheit = degF = degreeF
+
+# Volume
+liter = decimeter ** 3 = l = L = litre
+cubic_centimeter = centimeter ** 3 = cc
+
+# Force
+newton = kilogram * meter / second ** 2 = N
+
+# Energy
+joule = newton * meter = J
+electron_volt = e * volt = eV
+
+# Power
+watt = joule / second = W
+
+# Pressure
+pascal = newton / meter ** 2 = Pa
+
+#### UNIT GROUPS ####
+
+@group USCSLengthInternational
+    inch = yard / 36 = in = international_inch = inches = international_inches
+    foot = yard / 3 = ft = international_foot = feet = international_feet
+    yard = 0.9144 * meter = yd = international_yard  # since Jul 1959
+@end
+
+@group USCSLiquidVolume
+    minim = pint / 7680
+    fluid_dram = pint / 128 = fldr = fluidram = US_fluid_dram = US_liquid_dram
+    fluid_ounce = pint / 16 = floz = US_fluid_ounce = US_liquid_ounce
+    gill = pint / 4 = gi = liquid_gill = US_liquid_gill
+    pint = quart / 2 = pt = liquid_pint = US_pint
+    fifth = gallon / 5 = _ = US_liquid_fifth
+    quart = gallon / 4 = qt = liquid_quart = US_liquid_quart
+    gallon = 231 * cubic_inch = gal = liquid_gallon = US_liquid_gallon
+@end
+
+@group USCSVolumeOther
+    teaspoon = fluid_ounce / 6 = tsp
+    tablespoon = fluid_ounce / 2 = tbsp
+    shot = 3 * tablespoon = jig = US_shot
+    cup = pint / 2 = cp = liquid_cup = US_liquid_cup
+    barrel = 31.5 * gallon = bbl
+    oil_barrel = 42 * gallon = oil_bbl
+    beer_barrel = 31 * gallon = beer_bbl
+    hogshead = 63 * gallon
+@end
+
+@group Avoirdupois
+    ton = 2e3 * pound = _ = short_ton
+@end
+
+@group AvoirdupoisUS using Avoirdupois
+    US_ton = ton
+@end
+
+#### SYSTEMS OF UNITS ####
+
+@system SI
+    second
+    meter
+    kilogram
+    kelvin
+@end
+
+@system mks using international
+    meter
+    kilogram
+    second
+@end
+
+@system cgs using international, Gaussian, ESU
+    centimeter
+    gram
+    second
+@end

--- a/taurus/units/impl.py
+++ b/taurus/units/impl.py
@@ -1,5 +1,6 @@
 """Implementation of units."""
 import pint
+import pkg_resources
 from pint import UnitRegistry
 from pint.quantity import _Quantity
 from pint.unit import _Unit
@@ -10,7 +11,7 @@ except NameError:
     str = str
 
 # use the default unit registry for now
-_ureg = UnitRegistry()
+_ureg = UnitRegistry(filename=pkg_resources.resource_filename("taurus.units", "citrine_en.txt"))
 
 
 # alias the error that is thrown when units are incompatible
@@ -37,7 +38,7 @@ def parse_units(units):
     elif isinstance(units, _Unit):
         return _unit_to_str(units)
     else:
-        raise ValueError("Units must be given as a recognized unit string or Units object")
+        raise UndefinedUnitError("Units must be given as a recognized unit string or Units object")
 
 
 def convert_units(value, starting_unit, final_unit):

--- a/taurus/units/tests/test_parser.py
+++ b/taurus/units/tests/test_parser.py
@@ -1,0 +1,30 @@
+import pytest
+from taurus.units import parse_units, UndefinedUnitError
+
+
+def test_parse_expected():
+    """Test that we can parse the units that we expect to be able to."""
+    expected = [
+        "degC", "degF", "K",
+        "g", "kg", "mg", "ton",
+        "L", "mL",
+        "inch", "ft", "mm", "um",
+        "second", "ms", "hour", "minute", "ns",
+        "g/cm^3", "g/mL", "kg/cm^3"
+    ]
+    for unit in expected:
+        parse_units(unit)
+
+
+def test_parse_unexpected():
+    """Test that we cannot parse the units that we do not expect to."""
+    unexpected = [
+        "rankine",
+        "slug",
+        "hand",
+        "year",
+        "St"
+    ]
+    for unit in unexpected:
+        with pytest.raises(UndefinedUnitError):
+            parse_units(unit)


### PR DESCRIPTION
Pint supports _many_ units.  If we want to maintain the ability
to use different unit parsing libraries, then we should down select
the set of supported units to make the task of finding equivalents
easier.

This list can easily be added to as needed, of course.