### PR TITLE
Feature/pla 1413 repr has soft links

### DIFF
--- a/taurus/entity/dict_serializable.py
+++ b/taurus/entity/dict_serializable.py
@@ -82,7 +82,11 @@ class DictSerializable(ABC):
         return loads(dumps(d))
 
     def __repr__(self):
-        return str(self.as_dict())
+        object_dict = self.as_dict()
+        skipped_keys = {x.lstrip('_') for x in vars(self) if x in self.skip}
+        for key in skipped_keys:
+            object_dict[key] = self.__getattribute__(key)
+        return str(object_dict)
 
     def __eq__(self, other):
         if isinstance(other, DictSerializable):

--- a/taurus/entity/dict_serializable.py
+++ b/taurus/entity/dict_serializable.py
@@ -86,9 +86,9 @@ class DictSerializable(ABC):
         # as_dict() skips over keys in `skip`, but they should be in the representation.
         skipped_keys = {x.lstrip('_') for x in vars(self) if x in self.skip}
         for key in skipped_keys:
-            skipped_field = self.__getattribute__(key)
+            skipped_field = getattr(self, key, None)
             object_dict[key] = self._name_repr(skipped_field)
-        return object_dict.__str__()
+        return str(object_dict)
 
     def _name_repr(self, entity):
         """

--- a/taurus/entity/dict_serializable.py
+++ b/taurus/entity/dict_serializable.py
@@ -91,7 +91,11 @@ class DictSerializable(ABC):
             skipped_attribute = deepcopy(self.__getattribute__(key))
             # Replace links in skipped keys with LinkByUID to prevent infinite recursion loop.
             set_uuids(skipped_attribute)
-            substitute_links(skipped_attribute)
+            if isinstance(skipped_attribute, list):
+                for x in skipped_attribute:
+                    substitute_links(x)
+            else:
+                substitute_links(skipped_attribute)
             object_dict[key] = skipped_attribute
         return object_dict.__str__()
 

--- a/taurus/entity/object/ingredient_run.py
+++ b/taurus/entity/object/ingredient_run.py
@@ -108,7 +108,7 @@ class IngredientRun(BaseObject, HasQuantities):
         elif isinstance(process, ProcessRun):
             self._process = process
             if not isinstance(process.ingredients, ValidList):
-                process._ingredients = validate_list(self, IngredientRun)
+                process._ingredients = validate_list(self, [IngredientRun, LinkByUID])
             else:
                 process._ingredients.append(self)
         elif isinstance(process, LinkByUID):

--- a/taurus/entity/object/ingredient_spec.py
+++ b/taurus/entity/object/ingredient_spec.py
@@ -117,7 +117,7 @@ class IngredientSpec(BaseObject, HasQuantities):
         elif isinstance(process, ProcessSpec):
             self._process = process
             if not isinstance(process.ingredients, ValidList):
-                process._ingredients = validate_list(self, IngredientSpec)
+                process._ingredients = validate_list(self, [IngredientSpec, LinkByUID])
             else:
                 process._ingredients.append(self)
         elif isinstance(process, LinkByUID):

--- a/taurus/entity/object/measurement_run.py
+++ b/taurus/entity/object/measurement_run.py
@@ -78,7 +78,7 @@ class MeasurementRun(BaseObject, HasConditions, HasProperties, HasParameters, Ha
         elif isinstance(value, MaterialRun):
             self._material = value
             if not isinstance(value.measurements, ValidList):
-                value._measurements = validate_list(self, MeasurementRun)
+                value._measurements = validate_list(self, [MeasurementRun, LinkByUID])
             else:
                 value._measurements.append(self)
         elif isinstance(value, LinkByUID):

--- a/taurus/entity/object/tests/test_material_run.py
+++ b/taurus/entity/object/tests/test_material_run.py
@@ -59,6 +59,9 @@ def test_process_run():
     copy_material = loads(dumps(material_run))
     assert dumps(copy_material) == dumps(material_run)
 
+    assert 'output_material' in process_run.__repr__()
+    assert 'process' in material_run.foo()
+
 
 def test_process_id_link():
     """Test that a process run can house a LinkByUID object, and that it survives serde."""

--- a/taurus/entity/object/tests/test_material_run.py
+++ b/taurus/entity/object/tests/test_material_run.py
@@ -59,8 +59,8 @@ def test_process_run():
     copy_material = loads(dumps(material_run))
     assert dumps(copy_material) == dumps(material_run)
 
-    assert 'output_material' in process_run.__repr__()
-    assert 'process' in material_run.__repr__()
+    assert 'output_material' in repr(process_run)
+    assert 'process' in repr(material_run)
 
 
 def test_process_id_link():

--- a/taurus/entity/object/tests/test_material_run.py
+++ b/taurus/entity/object/tests/test_material_run.py
@@ -60,7 +60,7 @@ def test_process_run():
     assert dumps(copy_material) == dumps(material_run)
 
     assert 'output_material' in process_run.__repr__()
-    assert 'process' in material_run.foo()
+    assert 'process' in material_run.__repr__()
 
 
 def test_process_id_link():

--- a/taurus/entity/object/tests/test_measurement_run.py
+++ b/taurus/entity/object/tests/test_measurement_run.py
@@ -72,6 +72,8 @@ def test_material_soft_link():
         "Measurement information should be removed when material is serialized"
 
     assert 'measurements' in dye.__repr__()
+    assert 'material' in fluorescence.__repr__()
+    assert 'material' in absorbance.__repr__()
 
 
 def test_material_id_link():

--- a/taurus/entity/object/tests/test_measurement_run.py
+++ b/taurus/entity/object/tests/test_measurement_run.py
@@ -71,6 +71,8 @@ def test_material_soft_link():
     assert loads(dumps(dye)).measurements == [], \
         "Measurement information should be removed when material is serialized"
 
+    assert 'measurements' in dye.__repr__()
+
 
 def test_material_id_link():
     """Check that a measurement can be linked to a material that is a LinkByUID."""

--- a/taurus/entity/object/tests/test_measurement_run.py
+++ b/taurus/entity/object/tests/test_measurement_run.py
@@ -12,6 +12,7 @@ from taurus.entity.source.performed_source import PerformedSource
 from taurus.entity.value.nominal_real import NominalReal
 from taurus.entity.file_link import FileLink
 from taurus.entity.link_by_uid import LinkByUID
+from taurus.util.impl import substitute_links
 
 
 def test_measurement_spec():
@@ -74,6 +75,9 @@ def test_material_soft_link():
     assert 'measurements' in dye.__repr__()
     assert 'material' in fluorescence.__repr__()
     assert 'material' in absorbance.__repr__()
+
+    substitute_links(dye.measurements)
+    assert 'measurements' in dye.__repr__()
 
 
 def test_material_id_link():

--- a/taurus/entity/object/tests/test_measurement_run.py
+++ b/taurus/entity/object/tests/test_measurement_run.py
@@ -72,12 +72,12 @@ def test_material_soft_link():
     assert loads(dumps(dye)).measurements == [], \
         "Measurement information should be removed when material is serialized"
 
-    assert 'measurements' in dye.__repr__()
-    assert 'material' in fluorescence.__repr__()
-    assert 'material' in absorbance.__repr__()
+    assert 'measurements' in repr(dye)
+    assert 'material' in repr(fluorescence)
+    assert 'material' in repr(absorbance)
 
     substitute_links(dye.measurements)
-    assert 'measurements' in dye.__repr__()
+    assert 'measurements' in repr(dye)
 
 
 def test_material_id_link():

--- a/taurus/entity/object/tests/test_process_run.py
+++ b/taurus/entity/object/tests/test_process_run.py
@@ -33,5 +33,5 @@ def test_ingredient_run():
 
     assert proc_run_copy == proc_run, "Full structure wasn't preserved across serialization"
 
-    assert 'process' in ingred_run.__repr__()
-    assert 'ingredients' in proc_run.__repr__()
+    assert 'process' in repr(ingred_run)
+    assert 'ingredients' in repr(proc_run)

--- a/taurus/entity/object/tests/test_process_run.py
+++ b/taurus/entity/object/tests/test_process_run.py
@@ -26,9 +26,12 @@ def test_ingredient_run():
     """Tests that a process can house an ingredient, and that pairing survives serialization."""
     # Create a ProcessSpec
     proc_run = ProcessRun(name="a process spec", tags=["tag1", "tag2"])
-    IngredientRun(name='Input', material=MaterialRun(name='Raw'), process=proc_run)
+    ingred_run = IngredientRun(name='Input', material=MaterialRun(name='Raw'), process=proc_run)
 
     # Make copies of both specs
     proc_run_copy = loads(dumps(proc_run))
 
     assert proc_run_copy == proc_run, "Full structure wasn't preserved across serialization"
+
+    assert 'process' in ingred_run.__repr__()
+    assert 'ingredients' in proc_run.__repr__()


### PR DESCRIPTION
When displaying the `__repr__()` of a `DictSerializable`, include soft links. Those soft-linked objects have their pointers replaced with LinkByUID, to prevent infinite recursion loops.
I had to change the soft-linked `ValidList` objects (`measurements` in `MaterialRun`, `ingredients` in `ProcessRun` and `ProcessSpec`) to allow `LinkByUID`.