### PR TITLE
Feature/pla 1167 soft link reassignment

### DIFF
--- a/taurus/entity/object/ingredient_run.py
+++ b/taurus/entity/object/ingredient_run.py
@@ -103,6 +103,8 @@ class IngredientRun(BaseObject, HasQuantities):
     def process(self, process):
         from taurus.entity.object import ProcessRun
         from taurus.entity.link_by_uid import LinkByUID
+        if self._process is not None and isinstance(self._process, ProcessRun):
+            self._process._unset_ingredient(self)
         if process is None:
             self._process = None
         elif isinstance(process, ProcessRun):

--- a/taurus/entity/object/ingredient_spec.py
+++ b/taurus/entity/object/ingredient_spec.py
@@ -112,6 +112,8 @@ class IngredientSpec(BaseObject, HasQuantities):
     def process(self, process):
         from taurus.entity.object import ProcessSpec
         from taurus.entity.link_by_uid import LinkByUID
+        if self._process is not None and isinstance(self._process, ProcessSpec):
+            self._process._unset_ingredient(self)
         if process is None:
             self._process = None
         elif isinstance(process, ProcessSpec):

--- a/taurus/entity/object/material_run.py
+++ b/taurus/entity/object/material_run.py
@@ -81,6 +81,10 @@ class MaterialRun(BaseObject):
         """Get a list of measurement runs."""
         return self._measurements
 
+    def _unset_measurement(self, meas):
+        if meas in self._measurements:
+            self._measurements.remove(meas)
+
     @property
     def sample_type(self):
         """Get the sample type."""

--- a/taurus/entity/object/material_run.py
+++ b/taurus/entity/object/material_run.py
@@ -66,6 +66,8 @@ class MaterialRun(BaseObject):
     def process(self, process):
         from taurus.entity.object.process_run import ProcessRun
         from taurus.entity.link_by_uid import LinkByUID
+        if self.process is not None and isinstance(self.process, ProcessRun):
+            self.process._output_material = None
         if process is None:
             self._process = None
         elif isinstance(process, LinkByUID):
@@ -82,6 +84,7 @@ class MaterialRun(BaseObject):
         return self._measurements
 
     def _unset_measurement(self, meas):
+        """Remove `meas` from this material's list of measurements."""
         if meas in self._measurements:
             self._measurements.remove(meas)
 

--- a/taurus/entity/object/material_spec.py
+++ b/taurus/entity/object/material_spec.py
@@ -74,6 +74,8 @@ class MaterialSpec(BaseObject, HasTemplate):
         """
         from taurus.entity.object.process_spec import ProcessSpec
         from taurus.entity.link_by_uid import LinkByUID
+        if self.process is not None and isinstance(self.process, ProcessSpec):
+            self.process._output_material = None
         if process is None:
             self._process = None
         elif isinstance(process, LinkByUID):

--- a/taurus/entity/object/measurement_run.py
+++ b/taurus/entity/object/measurement_run.py
@@ -73,6 +73,8 @@ class MeasurementRun(BaseObject, HasConditions, HasProperties, HasParameters, Ha
     def material(self, value):
         from taurus.entity.object import MaterialRun
         from taurus.entity.link_by_uid import LinkByUID
+        if self._material is not None and isinstance(self._material, MaterialRun):
+            self._material._unset_measurement(self)
         if value is None:
             self._material = value
         elif isinstance(value, MaterialRun):

--- a/taurus/entity/object/process_run.py
+++ b/taurus/entity/object/process_run.py
@@ -78,6 +78,11 @@ class ProcessRun(BaseObject, HasConditions, HasParameters, HasSource):
         """Get the input ingredient runs."""
         return self._ingredients
 
+    def _unset_ingredient(self, ingred):
+        """Remove `ingred` from this process's list of ingredients."""
+        if ingred in self._ingredients:
+            self._ingredients.remove(ingred)
+
     @property
     def spec(self):
         """Get the process spec."""

--- a/taurus/entity/object/process_spec.py
+++ b/taurus/entity/object/process_spec.py
@@ -73,6 +73,11 @@ class ProcessSpec(BaseObject, HasParameters, HasConditions, HasTemplate):
         """Get the list of input ingredient specs."""
         return self._ingredients
 
+    def _unset_ingredient(self, ingred):
+        """Remove `ingred` from this process's list of ingredients."""
+        if ingred in self._ingredients:
+            self._ingredients.remove(ingred)
+
     @property
     def output_material(self):
         """Get the output material spec."""

--- a/taurus/entity/object/tests/test_ingredient_run.py
+++ b/taurus/entity/object/tests/test_ingredient_run.py
@@ -1,0 +1,24 @@
+"""Tests of the ingredient run object."""
+from taurus.entity.object.ingredient_run import IngredientRun
+from taurus.entity.object.process_run import ProcessRun
+
+
+def test_ingredient_reassignment():
+    """Check that an ingredient run can be re-assigned to a new process run."""
+    boiling = ProcessRun("Boil potatoes")
+    frying = ProcessRun("Fry potatoes")
+    oil = IngredientRun(name="Oil", process=boiling)
+    potatoes = IngredientRun(name="Potatoes", process=boiling)
+    assert oil.process == boiling
+    assert set(boiling.ingredients) == {oil, potatoes}
+    assert frying.ingredients == []
+
+    oil.process = frying
+    assert oil.process == frying
+    assert boiling.ingredients == [potatoes]
+    assert frying.ingredients == [oil]
+
+    potatoes.process = frying
+    assert potatoes.process == frying
+    assert boiling.ingredients == []
+    assert set(frying.ingredients) == {oil, potatoes}

--- a/taurus/entity/object/tests/test_ingredient_spec.py
+++ b/taurus/entity/object/tests/test_ingredient_spec.py
@@ -1,0 +1,24 @@
+"""Tests of the ingredient spec object."""
+from taurus.entity.object.ingredient_spec import IngredientSpec
+from taurus.entity.object.process_spec import ProcessSpec
+
+
+def test_ingredient_reassignment():
+    """Check that an ingredient spec can be re-assigned to a new process spec."""
+    boiling = ProcessSpec("Boil potatoes")
+    frying = ProcessSpec("Fry potatoes")
+    oil = IngredientSpec(name="Oil", process=boiling)
+    potatoes = IngredientSpec(name="Potatoes", process=boiling)
+    assert oil.process == boiling
+    assert set(boiling.ingredients) == {oil, potatoes}
+    assert frying.ingredients == []
+
+    oil.process = frying
+    assert oil.process == frying
+    assert boiling.ingredients == [potatoes]
+    assert frying.ingredients == [oil]
+
+    potatoes.process = frying
+    assert potatoes.process == frying
+    assert boiling.ingredients == []
+    assert set(frying.ingredients) == {oil, potatoes}

--- a/taurus/entity/object/tests/test_material_run.py
+++ b/taurus/entity/object/tests/test_material_run.py
@@ -67,3 +67,18 @@ def test_process_id_link():
     mat_run = MaterialRun("Another cake", process=proc_link)
     copy_material = loads(dumps(mat_run))
     assert dumps(copy_material) == dumps(mat_run)
+
+
+def test_process_reassignment():
+    """Test that a material can be assigned to a new process."""
+    drying = ProcessRun("drying")
+    welding = ProcessRun("welding")
+    powder = MaterialRun("Powder", process=welding)
+
+    assert powder.process == welding
+    assert welding.output_material == powder
+
+    powder.process = drying
+    assert powder.process == drying
+    assert drying.output_material == powder
+    assert welding.output_material is None

--- a/taurus/entity/object/tests/test_material_spec.py
+++ b/taurus/entity/object/tests/test_material_spec.py
@@ -1,0 +1,18 @@
+"""Tests of the material spec object."""
+from taurus.entity.object.process_spec import ProcessSpec
+from taurus.entity.object.material_spec import MaterialSpec
+
+
+def test_process_reassignment():
+    """Test that a material can be assigned to a new process."""
+    drying = ProcessSpec("drying")
+    welding = ProcessSpec("welding")
+    powder = MaterialSpec("Powder", process=welding)
+
+    assert powder.process == welding
+    assert welding.output_material == powder
+
+    powder.process = drying
+    assert powder.process == drying
+    assert drying.output_material == powder
+    assert welding.output_material is None

--- a/taurus/entity/object/tests/test_measurement_run.py
+++ b/taurus/entity/object/tests/test_measurement_run.py
@@ -88,3 +88,18 @@ def test_source():
 
     with pytest.raises(TypeError):
         MeasurementRun(name="Polonium", source="Marie Curie on 1898-07-01")
+
+
+def test_measurement_reassignment():
+    """Check that a measurement run can be re-assigned to a new material run."""
+    sample1 = MaterialRun("Sample 1")
+    sample2 = MaterialRun("Sample 2")
+    mass = MeasurementRun("Mass of sample", material=sample1)
+    assert mass.material == sample1
+    assert sample1.measurements == [mass]
+    assert sample2.measurements == []
+
+    mass.material = sample2
+    assert mass.material == sample2
+    assert sample1.measurements == []
+    assert sample2.measurements == [mass]

--- a/taurus/entity/object/tests/test_measurement_run.py
+++ b/taurus/entity/object/tests/test_measurement_run.py
@@ -95,11 +95,16 @@ def test_measurement_reassignment():
     sample1 = MaterialRun("Sample 1")
     sample2 = MaterialRun("Sample 2")
     mass = MeasurementRun("Mass of sample", material=sample1)
+    volume = MeasurementRun("Volume of sample", material=sample1)
     assert mass.material == sample1
-    assert sample1.measurements == [mass]
+    assert set(sample1.measurements) == {mass, volume}
     assert sample2.measurements == []
 
     mass.material = sample2
     assert mass.material == sample2
-    assert sample1.measurements == []
+    assert sample1.measurements == [volume]
     assert sample2.measurements == [mass]
+
+    mass.material = None
+    assert mass.material is None
+    assert sample2.measurements == []


### PR DESCRIPTION
Allows for reassignment of soft links. For example, if a measurement run `meas` is re-assigned from `mat1` to `mat2`, in addition to updating `mat2`'s `measurements` field to include `meas`, also update `mat1`'s `measurements` field to _no longer_ include `meas`. The same is done for ingredient run/specs in a process run/spec, and the `output_material` field of a process run/spec.