### PR TITLE
Increase test coverage with substitute_links() and ignoring demos

### DIFF
--- a/.coveragec
+++ b/.coveragec
@@ -2,4 +2,4 @@
 [run]
 omit =
     # omit demos
-    ./taurus/demo/*
+    taurus/demo/*

--- a/.coveragec
+++ b/.coveragec
@@ -1,5 +1,0 @@
-# Coverage config for pytest-cov
-[run]
-omit =
-    # omit everything (test)
-    *

--- a/.coveragec
+++ b/.coveragec
@@ -1,5 +1,5 @@
 # Coverage config for pytest-cov
 [run]
 omit =
-    # omit demos
-    taurus/demo/*
+    # omit everything (test)
+    *

--- a/.coveragec
+++ b/.coveragec
@@ -1,0 +1,5 @@
+# Coverage config for pytest-cov
+[run]
+omit =
+    # omit demos
+    ./taurus/demo/*

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
 - pip install -U -r test_requirements.txt
 - pip install --no-deps -e .
 script:
-- pytest --flake8 --cov=taurus --cov-report term-missing --cov-report term:skip-covered
+- pytest --flake8 --cov=taurus --cov-report term-missing --cov-report term:skip-covered --cov-config=tox.ini
   --cov-fail-under=91 -s -r ./taurus
 - cd docs; make html; cd ..;
 - touch ./docs/_build/html/.nojekyll

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
 - pip install --no-deps -e .
 script:
 - pytest --flake8 --cov=taurus --cov-report term-missing --cov-report term:skip-covered --cov-config=tox.ini
-  --cov-fail-under=91 -s -r ./taurus
+  --cov-fail-under=94 -s -r ./taurus
 - cd docs; make html; cd ..;
 - touch ./docs/_build/html/.nojekyll
 deploy:

--- a/taurus/client/tests/test_json.py
+++ b/taurus/client/tests/test_json.py
@@ -4,7 +4,7 @@ from taurus.entity.case_insensitive_dict import CaseInsensitiveDict
 from taurus.entity.attribute.condition import Condition
 from taurus.entity.attribute.parameter import Parameter
 from taurus.entity.link_by_uid import LinkByUID
-from taurus.entity.object import MeasurementRun, MaterialRun, ProcessRun
+from taurus.entity.object import MeasurementRun, MaterialRun, ProcessRun, ProcessSpec
 from taurus.entity.object.ingredient_run import IngredientRun
 from taurus.entity.object.ingredient_spec import IngredientSpec
 from taurus.entity.value.nominal_real import NominalReal
@@ -64,10 +64,8 @@ def test_dict_serialization():
     process = ProcessRun("A process")
     mat = MaterialRun("A material", process=process)
     meas = MeasurementRun("A measurement", material=mat)
-    meas_dict = meas.as_dict()
-    foo = dumps(meas_dict)
-    bar = loads(foo)
-    assert bar == meas
+    copy = loads(dumps(meas.as_dict()))
+    assert copy == meas
 
 
 def test_case_insensitive_rehydration():

--- a/taurus/client/tests/test_json.py
+++ b/taurus/client/tests/test_json.py
@@ -4,7 +4,7 @@ from taurus.entity.case_insensitive_dict import CaseInsensitiveDict
 from taurus.entity.attribute.condition import Condition
 from taurus.entity.attribute.parameter import Parameter
 from taurus.entity.link_by_uid import LinkByUID
-from taurus.entity.object import MeasurementRun, MaterialRun, ProcessRun, ProcessSpec
+from taurus.entity.object import MeasurementRun, MaterialRun, ProcessRun
 from taurus.entity.object.ingredient_run import IngredientRun
 from taurus.entity.object.ingredient_spec import IngredientSpec
 from taurus.entity.value.nominal_real import NominalReal

--- a/taurus/client/tests/test_json.py
+++ b/taurus/client/tests/test_json.py
@@ -59,6 +59,17 @@ def test_uid_deser():
     assert ingredient_copy.material.uids['sample id'] == material.uids['Sample ID']
 
 
+def test_dict_serialization():
+    """Test that a dictionary can be serialized and then deserialized as a taurus object."""
+    process = ProcessRun("A process")
+    mat = MaterialRun("A material", process=process)
+    meas = MeasurementRun("A measurement", material=mat)
+    meas_dict = meas.as_dict()
+    foo = dumps(meas_dict)
+    bar = loads(foo)
+    assert bar == meas
+
+
 def test_case_insensitive_rehydration():
     """
 

--- a/taurus/util/tests/test_substitute_links.py
+++ b/taurus/util/tests/test_substitute_links.py
@@ -1,9 +1,10 @@
 """Test the substitute_links method, in particular the edge cases that the client doesn't test."""
 import pytest
+from uuid import uuid4
 
 from taurus.util.impl import substitute_links
-from taurus.entity.object.measurement_run import MeasurementRun
-from taurus.entity.object.material_run import MaterialRun
+from taurus.entity.link_by_uid import LinkByUID
+from taurus.entity.object import MeasurementRun, MaterialRun, ProcessRun, ProcessSpec
 
 
 def test_substitution_without_id():
@@ -18,3 +19,20 @@ def test_substitution_without_id():
 
     with pytest.raises(ValueError):
         substitute_links(meas.as_dict()), "substitute_links should fail if objects don't have uids"
+
+    with pytest.raises(ValueError):
+        substitute_links({mat: meas})
+
+
+def test_object_key_substitution():
+    """Test that client can copy a dictionary in which keys are BaseEntity objects."""
+    spec = ProcessSpec("A process spec", uids={'id': str(uuid4()), 'auto': str(uuid4())})
+    run1 = ProcessRun("A process run", spec=spec, uids={'id': str(uuid4())})
+    run2 = ProcessRun("Another process run", spec=spec, uids={'id': str(uuid4())})
+    process_dict = {spec: [run1, run2]}
+
+    substitute_links(process_dict, native_uid='auto')
+    for key, value in process_dict.items():
+        assert key == LinkByUID.from_entity(spec, name='auto')
+        assert LinkByUID.from_entity(run1) in value
+        assert LinkByUID.from_entity(run2) in value

--- a/taurus/util/tests/test_substitute_links.py
+++ b/taurus/util/tests/test_substitute_links.py
@@ -1,0 +1,20 @@
+"""Test the substitute_links method, in particular the edge cases that the client doesn't test."""
+import pytest
+
+from taurus.util.impl import substitute_links
+from taurus.entity.object.measurement_run import MeasurementRun
+from taurus.entity.object.material_run import MaterialRun
+
+
+def test_substitution_without_id():
+    """Test that trying to substitute links if uids haven't been assigned throws an error."""
+    mat = MaterialRun("A material with no id")
+    meas = MeasurementRun("A measurement with no id", material=mat)
+    with pytest.raises(ValueError):
+        substitute_links(meas), "substitute_links should fail if objects don't have uids"
+
+    with pytest.raises(ValueError):
+        substitute_links([meas, mat]), "substitute_links should fail if objects don't have uids"
+
+    with pytest.raises(ValueError):
+        substitute_links(meas.as_dict()), "substitute_links should fail if objects don't have uids"

--- a/taurus/util/tests/test_substitute_links.py
+++ b/taurus/util/tests/test_substitute_links.py
@@ -33,9 +33,10 @@ def test_native_id_substitution():
     native_id = 'id1'
     other_id = 'id2'
     # Create measurement and material with two ids
-    mat = MaterialRun("A material", uids={native_id: str(uuid4()), other_id: str(uuid4())})
-    meas = MeasurementRun("A measurement", material=mat,
-                          uids={native_id: str(uuid4()), other_id: str(uuid4())})
+    mat = MaterialRun("A material", uids={
+        native_id: str(uuid4()), "an_id": str(uuid4()), "another_id": str(uuid4())})
+    meas = MeasurementRun("A measurement", material=mat, uids={
+        "some_id": str(uuid4()), native_id: str(uuid4()), "an_id": str(uuid4())})
 
     # Turn the material pointer into a LinkByUID using native_id
     substitute_links(meas, native_uid=native_id)
@@ -43,7 +44,7 @@ def test_native_id_substitution():
 
     # Put the measurement into a list and convert that into a LinkByUID using native_id
     measurements_list = [meas]
-    substitute_links(measurements_list)
+    substitute_links(measurements_list, native_uid=native_id)
     assert measurements_list == [LinkByUID.from_entity(meas, name=native_id)]
 
 

--- a/taurus/util/tests/test_substitute_links.py
+++ b/taurus/util/tests/test_substitute_links.py
@@ -31,7 +31,6 @@ def test_substitution_without_id():
 def test_native_id_substitution():
     """Test that the native id gets serialized, when specified."""
     native_id = 'id1'
-    other_id = 'id2'
     # Create measurement and material with two ids
     mat = MaterialRun("A material", uids={
         native_id: str(uuid4()), "an_id": str(uuid4()), "another_id": str(uuid4())})

--- a/taurus/util/tests/test_substitute_links.py
+++ b/taurus/util/tests/test_substitute_links.py
@@ -20,19 +20,48 @@ def test_substitution_without_id():
     with pytest.raises(ValueError):
         substitute_links(meas.as_dict()), "substitute_links should fail if objects don't have uids"
 
+    # Create a dictionary in which either the key or value is missing a uid
+    meas.add_uid('id', str(uuid4()))
     with pytest.raises(ValueError):
-        substitute_links({mat: meas})
+        substitute_links({mat: meas}), "substitute_links should fail if objects don't have uids"
+    with pytest.raises(ValueError):
+        substitute_links({meas: mat}), "substitute_links should fail if objects don't have uids"
+
+
+def test_native_id_substitution():
+    """Test that the native id gets serialized, when specified."""
+    native_id = 'id1'
+    other_id = 'id2'
+    # Create measurement and material with two ids
+    mat = MaterialRun("A material", uids={native_id: str(uuid4()), other_id: str(uuid4())})
+    meas = MeasurementRun("A measurement", material=mat,
+                          uids={native_id: str(uuid4()), other_id: str(uuid4())})
+
+    # Turn the material pointer into a LinkByUID using native_id
+    substitute_links(meas, native_uid=native_id)
+    assert meas.material == LinkByUID.from_entity(mat, name=native_id)
+
+    # Put the measurement into a list and convert that into a LinkByUID using native_id
+    measurements_list = [meas]
+    substitute_links(measurements_list)
+    assert measurements_list == [LinkByUID.from_entity(meas, name=native_id)]
 
 
 def test_object_key_substitution():
     """Test that client can copy a dictionary in which keys are BaseEntity objects."""
     spec = ProcessSpec("A process spec", uids={'id': str(uuid4()), 'auto': str(uuid4())})
-    run1 = ProcessRun("A process run", spec=spec, uids={'id': str(uuid4())})
+    run1 = ProcessRun("A process run", spec=spec, uids={'id': str(uuid4()), 'auto': str(uuid4())})
     run2 = ProcessRun("Another process run", spec=spec, uids={'id': str(uuid4())})
     process_dict = {spec: [run1, run2]}
 
     substitute_links(process_dict, native_uid='auto')
     for key, value in process_dict.items():
         assert key == LinkByUID.from_entity(spec, name='auto')
-        assert LinkByUID.from_entity(run1) in value
+        assert LinkByUID.from_entity(run1, name='auto') in value
         assert LinkByUID.from_entity(run2) in value
+
+    reverse_process_dict = {run2: spec}
+    substitute_links(reverse_process_dict, native_uid='auto')
+    for key, value in reverse_process_dict.items():
+        assert key == LinkByUID.from_entity(run2)
+        assert value == LinkByUID.from_entity(spec, name='auto')

--- a/tox.ini
+++ b/tox.ini
@@ -12,3 +12,8 @@ max-doc-length = 119
 # E221: When stripping hints for python 3.5 compliance, an extra space is left before operators
 ignore = D100,D104,D105,D107,D301,D401,E221
 
+
+[run]
+omit =
+    # omit demos
+    taurus/demo/*


### PR DESCRIPTION
Write tests to cover every line of `taurus.util.impl.substitute_links()` and update config file so that `demo/` is ignored. Bumps coverage to 94%.