### PR TITLE
Test coverage of values

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
 - pip install --no-deps -e .
 script:
 - pytest --flake8 --cov=taurus --cov-report term-missing --cov-report term:skip-covered --cov-config=tox.ini
-  --cov-fail-under=95 -s -r ./taurus
+  --cov-fail-under=96 -s -r ./taurus
 - cd docs; make html; cd ..;
 - touch ./docs/_build/html/.nojekyll
 deploy:

--- a/taurus/entity/value/discrete_categorical.py
+++ b/taurus/entity/value/discrete_categorical.py
@@ -42,7 +42,6 @@ class DiscreteCategorical(CategoricalValue):
         elif isinstance(probabilities, dict):
             if abs(sum(probabilities.values()) - 1.0) > 1.0e-9:
                 raise ValueError("probabilities must sum to 1.0")
-
             self._probabilities = keymap(validate_str, probabilities)
         else:
             raise TypeError("probabilities must be dict or single value")

--- a/taurus/entity/value/discrete_categorical.py
+++ b/taurus/entity/value/discrete_categorical.py
@@ -45,4 +45,4 @@ class DiscreteCategorical(CategoricalValue):
 
             self._probabilities = keymap(validate_str, probabilities)
         else:
-            raise ValueError("probabilities must be dict or single value")
+            raise TypeError("probabilities must be dict or single value")

--- a/taurus/entity/value/nominal_categorical.py
+++ b/taurus/entity/value/nominal_categorical.py
@@ -17,7 +17,8 @@ class NominalCategorical(CategoricalValue):
     typ = "nominal_categorical"
 
     def __init__(self, category=None):
-        self._category = category
+        self._category = None
+        self.category = category
 
     @property
     def category(self):
@@ -28,4 +29,5 @@ class NominalCategorical(CategoricalValue):
     def category(self, category):
         if category is None:
             self._category = None
-        self._category = validate_str(category)
+        else:
+            self._category = validate_str(category)

--- a/taurus/entity/value/nominal_composition.py
+++ b/taurus/entity/value/nominal_composition.py
@@ -41,7 +41,7 @@ class NominalComposition(CompositionValue):
         elif isinstance(quantities, list):
             self._quantities = dict(quantities)
         else:
-            raise ValueError("quantities must be dict or None")
+            raise TypeError("quantities must be dict or List of two-item lists or None")
 
     def as_dict(self):
         """

--- a/taurus/entity/value/tests/test_discrete_categorical.py
+++ b/taurus/entity/value/tests/test_discrete_categorical.py
@@ -1,0 +1,21 @@
+"""Tests of the DiscreteCategorical class."""
+import pytest
+
+from taurus.entity.value.discrete_categorical import DiscreteCategorical
+
+
+def test_probabilities_setter():
+    """Test that the probabilities can be set."""
+    test_probabilities = {"solid": 0.9, "liquid": 0.1}
+    test_categorical = DiscreteCategorical()
+    assert test_categorical.probabilities is None
+    test_categorical.probabilities = test_probabilities
+    assert test_categorical.probabilities == test_probabilities
+
+
+def test_invalid_assignment():
+    """Test that invalid assignment throws the appropriate error."""
+    with pytest.raises(TypeError):
+        DiscreteCategorical(probabilities=["solid", "liquid"])
+    with pytest.raises(ValueError):
+        DiscreteCategorical(probabilities={"solid": 0.9, "liquid": 0.2})

--- a/taurus/entity/value/tests/test_empirical_formula.py
+++ b/taurus/entity/value/tests/test_empirical_formula.py
@@ -1,11 +1,13 @@
 """Test parsing and serde of empirical chemical formulae."""
+import pytest
+
 from taurus.client.json_encoder import dumps, loads
 from taurus.entity.value.empirical_formula import EmpiricalFormula
 
 
 def test_all_elements():
-    """Check that we can parse a simple formula with only integer stoichiometries."""
-    for el in ["H", "He", "C", "Si"]:
+    """Check that list of all elements exists and has some select examples."""
+    for el in ["H", "He", "C", "Si", "Mg", "Al", "Co", "Ce"]:
         assert el in EmpiricalFormula.all_elements(), "Couldn't find {} in all_elements".format(el)
     assert len(EmpiricalFormula.all_elements()) == 103, "Expected 103 elements"
 
@@ -15,3 +17,18 @@ def test_json():
     empirical = EmpiricalFormula("Al94.5Si5.5")
     copy = loads(dumps(empirical))
     assert(copy == empirical)
+
+
+def test_formula_setter():
+    """Check that we can set the formula."""
+    test_formula = "CsPbBr1.5I1.5"
+    test_empirical = EmpiricalFormula()
+    assert test_empirical.formula is None
+    test_empirical.formula = test_formula
+    assert test_empirical.formula == test_formula
+
+
+def test_invalid_formula():
+    """Check that an invalid formula throws a TypeError."""
+    with pytest.raises(TypeError):
+        EmpiricalFormula(formula={"Al": 2, "O": 3})

--- a/taurus/entity/value/tests/test_nominal_categorical.py
+++ b/taurus/entity/value/tests/test_nominal_categorical.py
@@ -1,0 +1,11 @@
+"""Tests of the NominalCategorical class."""
+from taurus.entity.value.nominal_categorical import NominalCategorical
+
+
+def test_category_setter():
+    """Test that the category can be set."""
+    test_category = "salt"
+    test_categorical = NominalCategorical()
+    assert test_categorical.category is None
+    test_categorical.category = test_category
+    assert test_categorical.category == test_category

--- a/taurus/entity/value/tests/test_nominal_composition.py
+++ b/taurus/entity/value/tests/test_nominal_composition.py
@@ -1,0 +1,19 @@
+"""Tests of the NominalComposition class."""
+from taurus.entity.value.nominal_composition import NominalComposition
+
+
+def test_quantities_are_dict():
+    """Test that NominalComposition can be instantiated several ways, all producing a dict."""
+    test_composition = NominalComposition()
+    assert isinstance(test_composition.quantities, dict)
+    test_composition = NominalComposition(dict(acetone=0.25, methanol=0.75))
+    assert isinstance(test_composition.quantities, dict)
+    test_composition = NominalComposition([["gas", 0.7], ["plasma", 0.3]])
+    assert isinstance(test_composition.quantities, dict)
+
+
+def test_quantities_as_dict():
+    """Test that the as_dict() method represents `quantities` as a list."""
+    test_composition = NominalComposition(dict(acetone=0.25, methanol=0.75))
+    quantities = test_composition.as_dict().get('quantities')
+    assert isinstance(quantities, list) and len(quantities) == 2

--- a/taurus/entity/value/tests/test_nominal_composition.py
+++ b/taurus/entity/value/tests/test_nominal_composition.py
@@ -1,4 +1,6 @@
 """Tests of the NominalComposition class."""
+import pytest
+
 from taurus.entity.value.nominal_composition import NominalComposition
 
 
@@ -10,6 +12,12 @@ def test_quantities_are_dict():
     assert isinstance(test_composition.quantities, dict)
     test_composition = NominalComposition([["gas", 0.7], ["plasma", 0.3]])
     assert isinstance(test_composition.quantities, dict)
+
+
+def test_invalid_assignment():
+    """Test that invalid assignment produces a TypeError."""
+    with pytest.raises(TypeError):
+        NominalComposition(("a quantity", 55))
 
 
 def test_quantities_as_dict():

--- a/taurus/entity/value/tests/test_uniform_integer.py
+++ b/taurus/entity/value/tests/test_uniform_integer.py
@@ -1,0 +1,20 @@
+"""Tests of the UniformInteger class."""
+import pytest
+
+from taurus.entity.value.uniform_integer import UniformInteger
+
+
+def test_bounds_order():
+    """Lower bound must be <= upper bound."""
+    UniformInteger(3, 7)
+    UniformInteger(12, 12)
+    with pytest.raises(AssertionError):
+        UniformInteger(22, 18)
+
+
+def test_bounds_are_integers():
+    """Lower bound and upper bound must be integers."""
+    with pytest.raises(AssertionError):
+        UniformInteger(5.7, 10)
+    with pytest.raises(AssertionError):
+        UniformInteger(1, "five")

--- a/taurus/entity/value/tests/test_uniform_real.py
+++ b/taurus/entity/value/tests/test_uniform_real.py
@@ -21,3 +21,4 @@ def test_equality():
     assert value1 == value1
     assert value1 != value2  # Equality check does not do unit conversion.
     assert value1 != value3
+    assert value1 != 0.5

--- a/taurus/entity/value/tests/test_uniform_real.py
+++ b/taurus/entity/value/tests/test_uniform_real.py
@@ -1,0 +1,23 @@
+"""Tests of the UniformReal class."""
+import pytest
+
+from taurus.entity.value.uniform_real import UniformReal
+
+
+def test_bounds_order():
+    """Lower bound must be <= upper bound."""
+    UniformReal(4.4, 8.8, 'm')
+    UniformReal(100.0, 100.0, 'm')
+    with pytest.raises(AssertionError):
+        UniformReal(23.2, 18.9, 'm')
+
+
+def test_equality():
+    """Test that equality checks both bounds and integers."""
+    value1 = UniformReal(0, 1, '')
+    value2 = UniformReal(0, 100, 'cm')
+    value3 = UniformReal(0, 2, '')
+
+    assert value1 == value1
+    assert value1 != value2  # Equality check does not do unit conversion.
+    assert value1 != value3

--- a/taurus/entity/value/tests/test_uniform_real.py
+++ b/taurus/entity/value/tests/test_uniform_real.py
@@ -13,12 +13,12 @@ def test_bounds_order():
 
 
 def test_equality():
-    """Test that equality checks both bounds and integers."""
+    """Test that equality checks both bounds and units."""
     value1 = UniformReal(0, 1, '')
-    value2 = UniformReal(0, 100, 'cm')
+    value2 = UniformReal(0, 1, 'cm')
     value3 = UniformReal(0, 2, '')
 
     assert value1 == value1
-    assert value1 != value2  # Equality check does not do unit conversion.
+    assert value1 != value2
     assert value1 != value3
     assert value1 != 0.5

--- a/taurus/entity/value/uniform_integer.py
+++ b/taurus/entity/value/uniform_integer.py
@@ -18,7 +18,9 @@ class UniformInteger(IntegerValue):
     typ = "uniform_integer"
 
     def __init__(self, lower_bound=None, upper_bound=None):
-        self.lower_bound = lower_bound
-        self.upper_bound = upper_bound
+        assert isinstance(lower_bound, int)
+        assert isinstance(upper_bound, int)
         assert lower_bound <= upper_bound, \
             "the lower bound must be <= the upper bound"
+        self.lower_bound = lower_bound
+        self.upper_bound = upper_bound


### PR DESCRIPTION
Full coverage of modules in `taurus/entity/values/`. This bumps coverage to 96.6%. Also change some ValueErrors to TypeErrors, fix bug in `categorical` assignment of `NominalCategorical`, and check that `UniformInteger` bounds are ints.