### PR TITLE
Test coverage of `taurus/entities` directory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ install:
 - pip install --no-deps -e .
 script:
 - pytest --flake8 --cov=taurus --cov-report term-missing --cov-report term:skip-covered --cov-config=tox.ini
-  --cov-fail-under=97 -s -r ./taurus
+  --cov-fail-under=98 -s -r ./taurus
 - cd docs; make html; cd ..;
 - touch ./docs/_build/html/.nojekyll
 deploy:

--- a/taurus/entity/base_entity.py
+++ b/taurus/entity/base_entity.py
@@ -29,10 +29,6 @@ class BaseEntity(DictSerializable):
         self._uids = None
         self.uids = uids
 
-    def content_hash(self):
-        """A hash of the object's content."""
-        return str(sorted(list(self.__dict__.items())))
-
     @property
     def tags(self):
         """Get the tags."""

--- a/taurus/entity/bounds/real_bounds.py
+++ b/taurus/entity/bounds/real_bounds.py
@@ -93,19 +93,11 @@ class RealBounds(BaseBounds):
             A tuple of the (lower_bound, upper_bound) in the target units.
 
         """
-        # if neither have units, then just return the bounds
-        if not self.default_units and not target_units:
-            return self.lower_bound, self.upper_bound
-        # if either have units but both don't, then we can't return anything
-        elif not self.default_units or not target_units:
+        try:
+            lower_bound = units.convert_units(
+                self.lower_bound, self.default_units, target_units)
+            upper_bound = units.convert_units(
+                self.upper_bound, self.default_units, target_units)
+            return lower_bound, upper_bound
+        except units.IncompatibleUnitsError:
             return None, None
-        # if both have units, then we can try to convert
-        else:
-            try:
-                lower_bound = units.convert_units(
-                    self.lower_bound, self.default_units, target_units)
-                upper_bound = units.convert_units(
-                    self.upper_bound, self.default_units, target_units)
-                return lower_bound, upper_bound
-            except units.IncompatibleUnitsError:
-                return None, None

--- a/taurus/entity/bounds/tests/test_categorical_bounds.py
+++ b/taurus/entity/bounds/tests/test_categorical_bounds.py
@@ -29,6 +29,7 @@ def test_contains():
     assert bounds.contains(CategoricalBounds(categories={"spam"}))
     assert not bounds.contains(CategoricalBounds(categories={"spam", "foo"}))
     assert not bounds.contains(RealBounds(0.0, 2.0, ''))
+    assert not bounds.contains(None)
     with pytest.raises(TypeError):
         bounds.contains({"spam", "eggs"})
 

--- a/taurus/entity/bounds/tests/test_composition_bounds.py
+++ b/taurus/entity/bounds/tests/test_composition_bounds.py
@@ -29,6 +29,7 @@ def test_contains():
     assert bounds.contains(CompositionBounds(components={"spam"}))
     assert not bounds.contains(CompositionBounds(components={"foo"}))
     assert not bounds.contains(RealBounds(0.0, 2.0, ''))
+    assert not bounds.contains(None)
     with pytest.raises(TypeError):
         bounds.contains({"spam"})
 

--- a/taurus/entity/bounds/tests/test_integer_bounds.py
+++ b/taurus/entity/bounds/tests/test_integer_bounds.py
@@ -31,5 +31,6 @@ def test_contains():
     assert int_bounds.contains(IntegerBounds(0, 1))
     assert int_bounds.contains(IntegerBounds(1, 2))
     assert not int_bounds.contains(IntegerBounds(1, 3))
+    assert not int_bounds.contains(None)
     with pytest.raises(TypeError):
         int_bounds.contains([0, 1])

--- a/taurus/entity/bounds/tests/test_real_bounds.py
+++ b/taurus/entity/bounds/tests/test_real_bounds.py
@@ -6,7 +6,7 @@ from taurus.entity.bounds.real_bounds import RealBounds
 
 
 def test_contains():
-    """Make sure unit conversions are applied to boundss for contains."""
+    """Make sure unit conversions are applied to bounds for contains."""
     dim = RealBounds(lower_bound=0, upper_bound=100, default_units="degC")
     dim2 = RealBounds(lower_bound=33, upper_bound=200, default_units="degF")
     assert dim.contains(dim2)
@@ -37,6 +37,9 @@ def test_constructor_error():
         RealBounds(0, float("inf"), "meter")
 
     with pytest.raises(ValueError):
+        RealBounds(None, 10, '')
+
+    with pytest.raises(ValueError):
         RealBounds(0, 100)
 
     with pytest.raises(ValueError):
@@ -47,5 +50,6 @@ def test_type_mismatch():
     """Test that incompatible types cannot be matched against RealBounds."""
     bounds = RealBounds(0, 1, default_units="meters")
     assert not bounds.contains(IntegerBounds(0, 1))
+    assert not bounds.contains(None)
     with pytest.raises(TypeError):
         bounds.contains([.33, .66])

--- a/taurus/entity/object/tests/test_material_run.py
+++ b/taurus/entity/object/tests/test_material_run.py
@@ -128,7 +128,7 @@ def test_equality():
                             property=Property("a property", value=NominalReal(3, ''))),
                         tags=["a tag"])
     mat1 = MaterialRun("A material", spec=spec)
-    mat2 = MaterialRun("Another material", spec=spec)
+    mat2 = MaterialRun("A material", spec=spec, tags=["A tag"])
     assert mat1 == deepcopy(mat1)
     assert mat1 != mat2
     assert mat1 != "A material"

--- a/taurus/entity/object/tests/test_material_run.py
+++ b/taurus/entity/object/tests/test_material_run.py
@@ -101,7 +101,7 @@ def test_template_access():
     """A material run's template should be equal to its spec's template."""
     template = MaterialTemplate("material template", uids={'id': str(uuid4())})
     spec = MaterialSpec("A spec", uids={'id': str(uuid4())}, template=template)
-    mat = MaterialRun("A run", uids={'id': str(uuid4())}, spec=spec)
+    mat = MaterialRun("A run", uids=['id', str(uuid4())], spec=spec)
     assert mat.template == template
 
     mat.spec = LinkByUID.from_entity(spec)

--- a/taurus/entity/object/tests/test_material_run.py
+++ b/taurus/entity/object/tests/test_material_run.py
@@ -2,6 +2,7 @@
 import pytest
 import json
 from uuid import uuid4
+from copy import deepcopy
 
 from taurus.client.json_encoder import loads, dumps
 from taurus.entity.attribute.property_and_conditions import PropertyAndConditions
@@ -118,3 +119,16 @@ def test_build():
     mat_dict = mat.as_dict()
     mat_dict['spec'] = mat.spec.as_dict()
     assert MaterialRun.build(mat_dict) == mat
+
+
+def test_equality():
+    """Test that equality check works as expected."""
+    spec = MaterialSpec("A spec",
+                        properties=PropertyAndConditions(
+                            property=Property("a property", value=NominalReal(3, ''))),
+                        tags=["a tag"])
+    mat1 = MaterialRun("A material", spec=spec)
+    mat2 = MaterialRun("Another material", spec=spec)
+    assert mat1 == deepcopy(mat1)
+    assert mat1 != mat2
+    assert mat1 != "A material"

--- a/taurus/entity/object/tests/test_material_run.py
+++ b/taurus/entity/object/tests/test_material_run.py
@@ -90,6 +90,8 @@ def test_process_reassignment():
 def test_invalid_assignment():
     """Invalid assignments to `process` or `spec` throw a TypeError."""
     with pytest.raises(TypeError):
+        MaterialRun(name=12)
+    with pytest.raises(TypeError):
         MaterialRun("name", spec=ProcessRun("a process"))
     with pytest.raises(TypeError):
         MaterialRun("name", process=MaterialSpec("a spec"))

--- a/taurus/entity/object/tests/test_material_run.py
+++ b/taurus/entity/object/tests/test_material_run.py
@@ -106,3 +106,15 @@ def test_template_access():
 
     mat.spec = LinkByUID.from_entity(spec)
     assert mat.template is None
+
+
+def test_build():
+    """Test that build recreates the material."""
+    spec = MaterialSpec("A spec",
+                        properties=PropertyAndConditions(
+                            property=Property("a property", value=NominalReal(3, ''))),
+                        tags=["a tag"])
+    mat = MaterialRun(name="a material", spec=spec)
+    mat_dict = mat.as_dict()
+    mat_dict['spec'] = mat.spec.as_dict()
+    assert MaterialRun.build(mat_dict) == mat

--- a/taurus/entity/setters.py
+++ b/taurus/entity/setters.py
@@ -51,7 +51,7 @@ def validate_str(obj):
 
     """
     if not isinstance(obj, str):
-        raise ValueError("Expected a string but got {} instead".format(type(obj)))
+        raise TypeError("Expected a string but got {} instead".format(type(obj)))
 
     # If python 2 and the string isn't already unicode, turn it into unicode"""
     try:

--- a/taurus/entity/template/attribute_template.py
+++ b/taurus/entity/template/attribute_template.py
@@ -43,9 +43,9 @@ class AttributeTemplate(BaseEntity):
         return self._bounds
 
     @bounds.setter
-    def bounds(self, value):
-        if value is None:
+    def bounds(self, bounds):
+        if bounds is None:
             raise ValueError("Bounds are required on AttributeTemplate")
-        if not isinstance(value, BaseBounds):
-            raise ValueError("Bounds must be an instance of BaseBounds")
-        self._bounds = value
+        if not isinstance(bounds, BaseBounds):
+            raise TypeError("Bounds must be an instance of BaseBounds: {}".format(bounds))
+        self._bounds = bounds

--- a/taurus/entity/template/base_template.py
+++ b/taurus/entity/template/base_template.py
@@ -66,4 +66,4 @@ class BaseTemplate(BaseEntity):
                     return [first, second]
                 else:
                     raise ValueError("Range and template are inconsistent")
-        raise ValueError("Expected a template or (template, bounds) tuple")
+        raise TypeError("Expected a template or (template, bounds) tuple")

--- a/taurus/entity/template/base_template.py
+++ b/taurus/entity/template/base_template.py
@@ -66,4 +66,4 @@ class BaseTemplate(BaseEntity):
                     return [first, second]
                 else:
                     raise ValueError("Range and template are inconsistent")
-        raise TypeError("Expected a template or (template, bounds) tuple")
+        raise TypeError("Expected a template or (template, bounds) tuple")  # pragma: no cover

--- a/taurus/entity/template/tests/test_base_attribute_template.py
+++ b/taurus/entity/template/tests/test_base_attribute_template.py
@@ -3,6 +3,7 @@ import pytest
 
 from taurus.entity.bounds.categorical_bounds import CategoricalBounds
 from taurus.entity.bounds.real_bounds import RealBounds
+from taurus.entity.value.uniform_real import UniformReal
 from taurus.entity.template.attribute_template import AttributeTemplate
 from taurus.entity.template.property_template import PropertyTemplate
 from taurus.client.json_encoder import dumps, loads
@@ -23,6 +24,14 @@ def test_name_is_a_string():
         SampleAttributeTemplate(name=42, bounds=cat_bounds)
 
     assert "must be a string" in str(error.value)
+
+
+def test_invalid_bounds():
+    """Test that invalid bounds throw the appropriate error."""
+    with pytest.raises(ValueError):
+        SampleAttributeTemplate(name="name")  # Must have a bounds
+    with pytest.raises(TypeError):
+        SampleAttributeTemplate(name="name", bounds=UniformReal(0, 1, ''))
 
 
 def test_json():

--- a/taurus/entity/template/tests/test_process_template.py
+++ b/taurus/entity/template/tests/test_process_template.py
@@ -25,7 +25,7 @@ def test_allowed_names():
     allowed_names = ["THF", "Carbon Disulfide", "Dimethyl Ether"]
     proc_template = ProcessTemplate(name="test template", allowed_names=allowed_names)
     for name in allowed_names:
-        assert name in proc_template.allowed_labels
+        assert name in proc_template.allowed_names
 
 
 def test_allowed_labels():

--- a/taurus/entity/template/tests/test_process_template.py
+++ b/taurus/entity/template/tests/test_process_template.py
@@ -1,0 +1,41 @@
+"""Tests of the ProcessTemplate object."""
+import pytest
+
+from taurus.entity.template.process_template import ProcessTemplate
+from taurus.entity.template.condition_template import ConditionTemplate
+from taurus.entity.bounds.real_bounds import RealBounds
+
+
+def test_bounds_mismatch():
+    """Test that a mismatch between the attribute and given bounds throws a ValueError."""
+    attribute_bounds = RealBounds(0, 100, '')
+    object_bounds = RealBounds(200, 300, '')
+    cond_template = ConditionTemplate("a condition", bounds=attribute_bounds)
+    with pytest.raises(ValueError):
+        ProcessTemplate("a process template", conditions=[[cond_template, object_bounds]])
+
+
+def test_allowed_names():
+    """
+    Test that allowed_names can be assigned.
+
+    Presently allowed_names is not used for any validation, but this test can be expanded
+    if it is used in the future.
+    """
+    allowed_names = ["THF", "Carbon Disulfide", "Dimethyl Ether"]
+    proc_template = ProcessTemplate(name="test template", allowed_names=allowed_names)
+    for name in allowed_names:
+        assert name in proc_template.allowed_labels
+
+
+def test_allowed_labels():
+    """
+    Test that allowed_labels can be assigned.
+
+    Presently allowed_labels is not used for any validation, but this test can be expanded
+    if it is used in the future.
+    """
+    allowed_labels = ["solvent", "salt", "binder", "polymer"]
+    proc_template = ProcessTemplate(name="test template", allowed_labels=allowed_labels)
+    for label in allowed_labels:
+        assert label in proc_template.allowed_labels

--- a/taurus/entity/tests/test_entity.py
+++ b/taurus/entity/tests/test_entity.py
@@ -1,11 +1,7 @@
 """General tests of entities."""
 import pytest
-from uuid import uuid4
 
-from taurus.entity.attribute.condition import Condition
 from taurus.entity.object.ingredient_run import IngredientRun
-from taurus.entity.object.process_run import ProcessRun
-from taurus.entity.value.nominal_real import NominalReal
 
 
 def test_id_case_sensitivitiy():
@@ -16,17 +12,3 @@ def test_id_case_sensitivitiy():
     ingredient = IngredientRun(uids={'my_id': 'sample1'})
     assert ingredient.uids['my_id'] == 'sample1'
     assert ingredient.uids['MY_id'] == 'sample1'
-
-
-def test_content_hash():
-    """Test that the content has is a string with all expected fields."""
-    proc = ProcessRun("a process", uids={'id': str(uuid4())},
-                      conditions=Condition("something", value=NominalReal(-10, '')))
-    ingred = IngredientRun(name="ingredient", uids={'id': str(uuid4())},
-                           absolute_quantity=NominalReal(3.5, 'g'), process=proc)
-    ingred_hash = ingred.content_hash()
-    assert isinstance(ingred_hash, str)
-    assert 'absolute_quantity' in ingred_hash \
-           and 'name' in ingred_hash \
-           and 'uids' in ingred_hash \
-           and 'process' in ingred_hash

--- a/taurus/entity/tests/test_entity.py
+++ b/taurus/entity/tests/test_entity.py
@@ -1,7 +1,11 @@
 """General tests of entities."""
 import pytest
+from uuid import uuid4
 
+from taurus.entity.attribute.condition import Condition
 from taurus.entity.object.ingredient_run import IngredientRun
+from taurus.entity.object.process_run import ProcessRun
+from taurus.entity.value.nominal_real import NominalReal
 
 
 def test_id_case_sensitivitiy():
@@ -12,3 +16,17 @@ def test_id_case_sensitivitiy():
     ingredient = IngredientRun(uids={'my_id': 'sample1'})
     assert ingredient.uids['my_id'] == 'sample1'
     assert ingredient.uids['MY_id'] == 'sample1'
+
+
+def test_content_hash():
+    """Test that the content has is a string with all expected fields."""
+    proc = ProcessRun("a process", uids={'id': str(uuid4())},
+                      conditions=Condition("something", value=NominalReal(-10, '')))
+    ingred = IngredientRun(name="ingredient", uids={'id': str(uuid4())},
+                           absolute_quantity=NominalReal(3.5, 'g'), process=proc)
+    ingred_hash = ingred.content_hash()
+    assert isinstance(ingred_hash, str)
+    assert 'absolute_quantity' in ingred_hash \
+           and 'name' in ingred_hash \
+           and 'uids' in ingred_hash \
+           and 'process' in ingred_hash

--- a/taurus/entity/tests/test_util.py
+++ b/taurus/entity/tests/test_util.py
@@ -1,6 +1,7 @@
 """Tests of entity utils."""
-from taurus.entity.util import make_instance
+import pytest
 
+from taurus.entity.util import make_instance
 from taurus.entity.object.ingredient_spec import IngredientSpec
 from taurus.entity.object.ingredient_run import IngredientRun
 from taurus.entity.object.material_spec import MaterialSpec
@@ -9,6 +10,8 @@ from taurus.entity.object.measurement_spec import MeasurementSpec
 from taurus.entity.object.measurement_run import MeasurementRun
 from taurus.entity.object.process_spec import ProcessSpec
 from taurus.entity.object.process_run import ProcessRun
+from taurus.entity.attribute.condition import Condition
+from taurus.entity.value.uniform_real import UniformReal
 
 
 def test_make_instance():
@@ -31,3 +34,20 @@ def test_make_instance():
     ingredient = mat_run.process.ingredients[0]
     assert ingredient.spec == mat_run.spec.process.ingredients[0]
     assert ingredient.material.spec == mat_run.spec.process.ingredients[0].material
+
+
+def test_invalid_instance():
+    """Calling make_instance on a non-spec should throw a TypeError."""
+    not_specs = [MeasurementRun("meas"), Condition("cond"), UniformReal(0, 1, ''), 'foo', 10]
+    for not_spec in not_specs:
+        with pytest.raises(TypeError):
+            make_instance(not_spec)
+
+
+def test_circular_crawl():
+    """Test that make_instance can handle a circular set of linked objects."""
+    proc = ProcessSpec("process name")
+    mat = MaterialSpec("material name", process=proc)
+    ingred = IngredientSpec(name="ingredient name", material=mat, process=proc)
+    mat_run = make_instance(mat)
+    assert mat_run == mat_run.process.ingredients[0].material

--- a/taurus/entity/tests/test_util.py
+++ b/taurus/entity/tests/test_util.py
@@ -48,6 +48,6 @@ def test_circular_crawl():
     """Test that make_instance can handle a circular set of linked objects."""
     proc = ProcessSpec("process name")
     mat = MaterialSpec("material name", process=proc)
-    ingred = IngredientSpec(name="ingredient name", material=mat, process=proc)
+    IngredientSpec(name="ingredient name", material=mat, process=proc)
     mat_run = make_instance(mat)
     assert mat_run == mat_run.process.ingredients[0].material

--- a/taurus/entity/tests/test_valid_list.py
+++ b/taurus/entity/tests/test_valid_list.py
@@ -1,5 +1,6 @@
 """Tests of the ValidList class."""
 import pytest
+
 from taurus.entity.valid_list import ValidList
 
 
@@ -13,15 +14,13 @@ def test_access_data():
     assert lo_strings == ['a', 'b', 'c', 'd', 'e', 'f']
 
     with pytest.raises(TypeError):
-        ValidList(_list=tuple([1, 1]), content_type=1)
-    with pytest.raises(TypeError):
-        ValidList(_list=tuple([1, 1]), content_type=None)
-    with pytest.raises(TypeError):
         lo_strings[0] = 1
     with pytest.raises(TypeError):
         lo_strings.append(1)
     with pytest.raises(TypeError):
         lo_strings.extend(tuple([1]))
+    with pytest.raises(TypeError):
+        lo_strings.extend(1)
     with pytest.raises(TypeError):
         lo_strings.insert(2, 1)
 
@@ -47,4 +46,16 @@ def test_triggers():
     vlst.append(1)
     vlst.extend([1])
     vlst.insert(2, 1)
+    vlst[0] = 17
     assert len(vlst) == 5
+    assert len(stash) == 6
+
+
+def test_invalid_content():
+    """Test that an invalid content_type throws a TypeError."""
+    with pytest.raises(TypeError):
+        ValidList(['z'], content_type={'types': [str]})
+    with pytest.raises(TypeError):
+        ValidList(_list=tuple([1, 1]), content_type=1)
+    with pytest.raises(TypeError):
+        ValidList(_list=tuple([1, 1]), content_type=None)

--- a/taurus/entity/util.py
+++ b/taurus/entity/util.py
@@ -84,9 +84,9 @@ def array_like():
         try:
             import pandas as pd
             _array_like = (list, tuple, np.ndarray, pd.core.base.PandasObject)
-        except ImportError:
-            _array_like = (list, tuple, np.ndarray)
-    except ImportError:
-        _array_like = (list, tuple)
+        except ImportError:  # pragma: no cover
+            _array_like = (list, tuple, np.ndarray)  # pragma: no cover
+    except ImportError:  # pragma: no cover
+        _array_like = (list, tuple)  # pragma: no cover
 
     return _array_like


### PR DESCRIPTION
Tests of bounds, `build`, equality, instantiating uids using a list,  `allowed_names`, `allowed_labels`, `content_hash`, `make_instance`, and the `ValidList` class.

Brings coverage to 98.3%