### PR TITLE
Document supported units

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,19 @@
 # taurus
-Python binding for Citrine's nextgen data concepts (codename: taurus). 
+Python binding for Citrine's nextgen data model (codename: taurus). 
 
+This package provides a framework for storing information about the processes that create materials, the materials themselves, and measurements performed on those materials. 
 
-Provides a framework for storing information about the processes that create materials, the materials themselves, and measurements performed on those materials. 
-Detailed documentation of the next gen format can be found in the language-agnostic documentation.
+## Usage
 
-## Installation
+To install `taurus`, you can simply:
+```
+$ pip install taurus-citrine
+```
+
+Documentation of this package can be found at https://citrineinformatics.github.io/taurus/
+Detailed documentation of the `taurus` data model can be found in the [language-agnostic documentation](https://citrineinformatics.github.io/taurus-documentation/).
+
+## Developer instructions
 To download the repo and install requirements, run 
 
 ```pip install git+https://github.com/CitrineInformatics/taurus.git```
@@ -16,14 +24,9 @@ In order to assess coverage locally, run `pytest` with the following arguments:
 * `--cov-report term-missing` Prints line numbers for lines that are not executed (optional)
 * `--cov-report term:skip-covered` Skips output for modules with full coverage (optional)
 * `--cov-report xml` Saves coverage report to `coverage.xml` (optional)
-* `--cov-fail-under=85` Throws an error if coverage is less than 85% (optional)
+* `--cov-fail-under=100` Throws an error if coverage is less than 100% (optional)
 
-The following command will run all tests, print line numbers for lines that are not executed, skip modules with full coverage, and fail if coverage is less than 85%:
-`python -m pytest --cov=taurus/ --cov-report term:skip-covered --cov-report term-missing --cov-fail-under=85`
+The following command will run all tests, print line numbers for lines that are not executed, skip modules with full coverage, and fail if coverage is less than 100%:
+`python -m pytest --cov=taurus/ --cov-report term:skip-covered --cov-report term-missing --cov-fail-under=100`
 
-## Usage
-Ingester scripts are used to import real-world materials data. 
-The results can then be serialized to JSON, and deserialized back into Taurus. 
 
-An example ingester can be found in `/taurus/ingest/material_run_example.py`, and code that feeds example data into the ingester is at `taurus/ingest/tests/test_material_run_example.py`. 
-For details, see `taurus/ingest/readme.md`.

--- a/docs/source/depth/index.rst
+++ b/docs/source/depth/index.rst
@@ -1,0 +1,8 @@
+======================
+In depth documentation
+======================
+
+.. toctree::
+   :maxdepth: 2
+
+   unit_parsing

--- a/docs/source/depth/unit_parsing.rst
+++ b/docs/source/depth/unit_parsing.rst
@@ -1,0 +1,14 @@
+==========================
+Unit Parsing
+==========================
+
+Unit parsing is performed using the Pint_ package.
+By default, Pint supports a larger set of units than the Citrine Platform.
+Therefore, we include a custom unit definition file in Taurus: `citrine_en.txt`_.
+This file contains the most commonly used units and will grow over time.
+
+Requests for support of additional units can be made by opening an issue in the `taurus repository`_ on github.
+
+.. _Pint: https://pint.readthedocs.io/en/0.9/
+.. _citrine_en.txt: https://github.com/CitrineInformatics/taurus/blob/master/taurus/units/citrine_en.txt
+.. _taurus repository: https://github.com/CitrineInformatics/taurus

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -6,10 +6,6 @@
 Welcome to the Taurus Documentation!
 ===================================================
 
-.. toctree::
-   :maxdepth: 2
-   :caption: Contents:
-
 Taurus is the Python implementation of the Citrine data model, the full documentation of which
 can be found `here <https://citrineinformatics.github.io/taurus-documentation/>`_.
 
@@ -22,8 +18,10 @@ Table of Contents
    :maxdepth: 2
    :numbered: 4
 
+   depth/index
+
 Indices and tables
-==================
+------------------
 
 * :ref:`genindex`
 * :ref:`modindex`


### PR DESCRIPTION
This adds an "In depth documentation" section to the sphinx docs with a "Unit parsing" page that describes how we down-select from pint.