### PR TITLE
Ignore extra kwargs in DictSerializable.from_dict

### DIFF
--- a/taurus/client/tests/test_json.py
+++ b/taurus/client/tests/test_json.py
@@ -52,6 +52,12 @@ def test_deserialize():
     assert(copy_meas.uids["auto"] == measurement.uids["auto"])
 
 
+def test_deserialize_extra_fields():
+    """Extra JSON fields should be ignored in deserialization."""
+    json_data = '[[], {"nominal": 5, "type": "nominal_real", "extra garbage": "foo"}]'
+    assert(loads(json_data) == NominalReal(nominal=5))
+
+
 def test_enumeration_serde():
     """An enumeration should get serialized as a string."""
     condition = Condition(name="A condition", notes=Origin.UNKNOWN)

--- a/taurus/client/tests/test_json.py
+++ b/taurus/client/tests/test_json.py
@@ -11,6 +11,7 @@ from taurus.entity.link_by_uid import LinkByUID
 from taurus.entity.object import MeasurementRun, MaterialRun, ProcessRun, MeasurementSpec
 from taurus.entity.object.ingredient_run import IngredientRun
 from taurus.entity.object.ingredient_spec import IngredientSpec
+from taurus.entity.value.nominal_integer import NominalInteger
 from taurus.entity.value.nominal_real import NominalReal
 from taurus.entity.value.normal_real import NormalReal
 from taurus.enumeration.origin import Origin
@@ -54,8 +55,8 @@ def test_deserialize():
 
 def test_deserialize_extra_fields():
     """Extra JSON fields should be ignored in deserialization."""
-    json_data = '[[], {"nominal": 5, "type": "nominal_real", "extra garbage": "foo"}]'
-    assert(loads(json_data) == NominalReal(nominal=5))
+    json_data = '[[], {"nominal": 5, "type": "nominal_integer", "extra garbage": "foo"}]'
+    assert(loads(json_data) == NominalInteger(nominal=5))
 
 
 def test_enumeration_serde():

--- a/taurus/entity/dict_serializable.py
+++ b/taurus/entity/dict_serializable.py
@@ -31,7 +31,7 @@ class DictSerializable(ABC):
             The deserialized object.
 
         """
-        arg_names = inspect.getfullargspec(cls.__init__).args
+        expected_arg_names = inspect.getfullargspec(cls.__init__).args
         kwargs = {}
         for name, arg in d.items():
             if name in arg_names:

--- a/taurus/entity/dict_serializable.py
+++ b/taurus/entity/dict_serializable.py
@@ -37,7 +37,7 @@ class DictSerializable(ABC):
             if name in arg_names:
                 kwargs[name] = arg
             else:
-                logger.warning('Ignoring unexpected kwarg in {}: {}'.format(__name__, name))
+                logger.warning('Ignoring unexpected keyword argument in {}: {}'.format(__name__, name))
         # noinspection PyArgumentList
         # DictSerializable's constructor is not intended for use,
         # but all of its children will use from_dict like this.

--- a/taurus/entity/dict_serializable.py
+++ b/taurus/entity/dict_serializable.py
@@ -1,5 +1,12 @@
 from abc import ABC
+from logging import getLogger
+
 import json
+import inspect
+
+# There are some weird (probably resolvable) errors during object cloning if this is an
+# instance variable of DictSerializable.
+logger = getLogger(__name__)
 
 
 class DictSerializable(ABC):
@@ -24,10 +31,17 @@ class DictSerializable(ABC):
             The deserialized object.
 
         """
+        arg_names = inspect.getfullargspec(cls.__init__).args
+        kwargs = {}
+        for name, arg in d.items():
+            if name in arg_names:
+                kwargs[name] = arg
+            else:
+                logger.warning('Ignoring unexpected kwarg in {}: {}'.format(__name__, name))
         # noinspection PyArgumentList
         # DictSerializable's constructor is not intended for use,
         # but all of its children will use from_dict like this.
-        return cls(**d)
+        return cls(**kwargs)
 
     def as_dict(self):
         """

--- a/taurus/entity/dict_serializable.py
+++ b/taurus/entity/dict_serializable.py
@@ -34,7 +34,7 @@ class DictSerializable(ABC):
         expected_arg_names = inspect.getfullargspec(cls.__init__).args
         kwargs = {}
         for name, arg in d.items():
-            if name in arg_names:
+            if name in expected_arg_names:
                 kwargs[name] = arg
             else:
                 logger.warning('Ignoring unexpected keyword argument in {}: {}'.format(__name__, name))

--- a/taurus/entity/dict_serializable.py
+++ b/taurus/entity/dict_serializable.py
@@ -37,8 +37,8 @@ class DictSerializable(ABC):
             if name in expected_arg_names:
                 kwargs[name] = arg
             else:
-                logger.warning('Ignoring unexpected keyword argument in {}: {}'
-                               .format(cls.__name__, name))
+                logger.warning('Ignoring unexpected keyword argument in {}: {}'.format(
+                    cls.__name__, name))
         # noinspection PyArgumentList
         # DictSerializable's constructor is not intended for use,
         # but all of its children will use from_dict like this.

--- a/taurus/entity/dict_serializable.py
+++ b/taurus/entity/dict_serializable.py
@@ -37,7 +37,8 @@ class DictSerializable(ABC):
             if name in expected_arg_names:
                 kwargs[name] = arg
             else:
-                logger.warning('Ignoring unexpected keyword argument in {}: {}'.format(__name__, name))
+                logger.warning('Ignoring unexpected keyword argument in {}: {}'
+                               .format(cls.__name__, name))
         # noinspection PyArgumentList
         # DictSerializable's constructor is not intended for use,
         # but all of its children will use from_dict like this.


### PR DESCRIPTION
This will make backward-compatibility of the backend with python clients easier to maintain.