### PR TITLE
Pla 1523/attribute serde

### DIFF
--- a/taurus/client/tests/test_json.py
+++ b/taurus/client/tests/test_json.py
@@ -3,6 +3,8 @@ import json
 import pytest
 
 from taurus.client.json_encoder import dumps, loads, copy, thin_dumps
+from taurus.entity.attribute.property import Property
+from taurus.entity.bounds.real_bounds import RealBounds
 from taurus.entity.dict_serializable import DictSerializable
 from taurus.entity.case_insensitive_dict import CaseInsensitiveDict
 from taurus.entity.attribute.condition import Condition
@@ -11,6 +13,7 @@ from taurus.entity.link_by_uid import LinkByUID
 from taurus.entity.object import MeasurementRun, MaterialRun, ProcessRun, MeasurementSpec
 from taurus.entity.object.ingredient_run import IngredientRun
 from taurus.entity.object.ingredient_spec import IngredientSpec
+from taurus.entity.template.property_template import PropertyTemplate
 from taurus.entity.value.nominal_integer import NominalInteger
 from taurus.entity.value.nominal_real import NominalReal
 from taurus.entity.value.normal_real import NormalReal
@@ -64,6 +67,18 @@ def test_enumeration_serde():
     condition = Condition(name="A condition", notes=Origin.UNKNOWN)
     copy_condition = copy(condition)
     assert copy_condition.notes == Origin.get_value(condition.notes)
+
+
+def test_attribute_serde():
+    """An attribute with a link to an attribute template should be copy-able."""
+    prop_tmpl = PropertyTemplate(name='prop_tmpl',
+                                 bounds=RealBounds(0, 2, 'm')
+                                 )
+    prop = Property(name='prop',
+                    template=prop_tmpl,
+                    value=NominalReal(1, 'm')
+                    )
+    assert loads(dumps(prop)) == prop
 
 
 def test_thin_dumps():

--- a/taurus/client/tests/test_json.py
+++ b/taurus/client/tests/test_json.py
@@ -78,7 +78,11 @@ def test_attribute_serde():
                     template=prop_tmpl,
                     value=NominalReal(1, 'm')
                     )
+    meas_spec = MeasurementSpec("a spec")
+    meas = MeasurementRun("a measurement", spec=meas_spec, properties=[prop])
     assert loads(dumps(prop)) == prop
+    assert loads(dumps(meas)) == meas
+    assert isinstance(prop.template, PropertyTemplate)
 
 
 def test_thin_dumps():

--- a/taurus/util/impl.py
+++ b/taurus/util/impl.py
@@ -254,7 +254,9 @@ def _recursive_substitute(obj, native_uid=None, seen=None):
                     uid_to_use = next(iter(x.uids.items()))
                     obj[i] = LinkByUID(uid_to_use[0], uid_to_use[1])
             else:
-                _recursive_substitute(x, native_uid, seen)
+                # The list/tuple obj is modified, but the object inside it is not
+                obj[i] = deepcopy(x)
+                _recursive_substitute(obj[i], native_uid, seen)
     elif isinstance(obj, dict):
         for k, x in obj.items():
             if isinstance(x, BaseEntity):


### PR DESCRIPTION
This PR identifies a bug when serializing attributes with attribute templates. The original attribute gets modified so that it points to a `LinkByUID` instead of the attribute template.

The flaw lies in the `dumps()` method, which includes the code
```
res = [obj]
substitute_links(res)
```
In the normal case, `obj` is a `BaseEntity`. Now, `substitute_links` is an in-place operation, but in this case that means _the list is modified_, not the object inside of it. `res` gets modified as `res[i] = LinkByUID(...)` so it goes from being a list with one `BaseEntity` to a list with one `LinkByUID`. But `obj` doesn't get modified.
Something different happens when the element in the list is a `DictSerializable` that's not a `BaseEntity`, as is the case for attributes or values or bounds. The `recursive_substitute` method is called directly on the element of list, modifying it. That means that if `obj` is an attribute with a link to an attribute template, it gets modified to point to a `LinkByUID`. 
To make the behavior similar to that for `BaseEntity`s (modify the list, not the object inside the list), I've changed it so that the element of the list is copied, `recursive_substitue` is called on the copy, and that is stuck into the list.