### PR TITLE
Feature/pla 1951 citrine python taurus integration

### DIFF
--- a/taurus/client/json_encoder.py
+++ b/taurus/client/json_encoder.py
@@ -140,8 +140,8 @@ def thin_dumps(obj, **kwargs):
 
     Parameters
     ----------
-    obj: BaseEntity
-        Object to dump (must be a BaseEntity because it must have uids)
+    obj:
+        Object to dump
     **kwargs: keyword args, optional
         Optional keyword arguments to pass to `json.dumps()`.
 
@@ -151,8 +151,6 @@ def thin_dumps(obj, **kwargs):
         A serialized string of `obj`, with link_by_uid in place of pointers to other objects.
 
     """
-    if not isinstance(obj, BaseEntity):
-        raise TypeError("Can only dump BaseEntities, but got {}".format(type(obj)))
 
     set_uuids(obj)
     res = deepcopy(obj)

--- a/taurus/client/json_encoder.py
+++ b/taurus/client/json_encoder.py
@@ -151,7 +151,6 @@ def thin_dumps(obj, **kwargs):
         A serialized string of `obj`, with link_by_uid in place of pointers to other objects.
 
     """
-
     set_uuids(obj)
     res = deepcopy(obj)
     substitute_links(res)

--- a/taurus/client/tests/test_json.py
+++ b/taurus/client/tests/test_json.py
@@ -86,7 +86,7 @@ def test_attribute_serde():
 
 
 def test_thin_dumps():
-    """Test that thin_dumps turns pointers into links and doesn't work on non-BaseEntity."""
+    """Test that thin_dumps turns pointers into links"""
     mat = MaterialRun("The actual material")
     meas_spec = MeasurementSpec("measurement", uids={'my_scope': '324324'})
     meas = MeasurementRun("The measurement", spec=meas_spec, material=mat)
@@ -97,8 +97,9 @@ def test_thin_dumps():
     assert isinstance(thin_copy.spec, LinkByUID)
     assert thin_copy.spec.id == meas_spec.uids['my_scope']
 
-    with pytest.raises(TypeError):
-        thin_dumps(LinkByUID('scope', 'id'))
+    # Check that LinkByUID objects are correctly converted their JSON equivalent
+    expected_json = '{"id": "my_id", "scope": "scope", "type": "link_by_uid"}'
+    assert thin_dumps(LinkByUID('scope', 'my_id')) == expected_json
 
 
 def test_uid_deser():

--- a/taurus/client/tests/test_json.py
+++ b/taurus/client/tests/test_json.py
@@ -101,6 +101,10 @@ def test_thin_dumps():
     expected_json = '{"id": "my_id", "scope": "scope", "type": "link_by_uid"}'
     assert thin_dumps(LinkByUID('scope', 'my_id')) == expected_json
 
+    # Check that objects lacking .uid attributes will raise an exception when dumped
+    with pytest.raises(TypeError):
+        thin_dumps({{'key': 'value'}})
+
 
 def test_uid_deser():
     """Test that uids continue to be a CaseInsensitiveDict after deserialization."""

--- a/taurus/client/tests/test_json.py
+++ b/taurus/client/tests/test_json.py
@@ -86,7 +86,7 @@ def test_attribute_serde():
 
 
 def test_thin_dumps():
-    """Test that thin_dumps turns pointers into links"""
+    """Test that thin_dumps turns pointers into links."""
     mat = MaterialRun("The actual material")
     meas_spec = MeasurementSpec("measurement", uids={'my_scope': '324324'})
     meas = MeasurementRun("The measurement", spec=meas_spec, material=mat)

--- a/taurus/entity/dict_serializable.py
+++ b/taurus/entity/dict_serializable.py
@@ -71,8 +71,8 @@ class DictSerializable(ABC):
             A string representation of the object as a dictionary.
 
         """
-        from taurus.client.json_encoder import dumps
-        return json.loads(dumps(self))[1]
+        from taurus.client.json_encoder import thin_dumps
+        return json.loads(thin_dumps(self))
 
     @staticmethod
     def build(d):

--- a/taurus/util/impl.py
+++ b/taurus/util/impl.py
@@ -65,20 +65,22 @@ def substitute_objects(obj, index):
                 else:
                     substitute(x)
         elif isinstance(thing, dict):
-            for k, v in thing.items():
+            # we are restricted from modifying the keys of a dict while iterating over it's
+            # items so we iterate over a copy of the dict instead.
+            for k, v in thing.copy().items():
                 if isinstance(v, LinkByUID) and (v.scope.lower(), v.id) in index:
                     thing[k] = index[(v.scope.lower(), v.id)]
                     substitute(thing[k])
                 else:
                     substitute(v)
-            for k, v in thing.items():
+            for k, v in thing.copy().items():
                 if isinstance(k, LinkByUID) and (k.scope.lower(), k.id) in index:
                     thing[index[(k.scope.lower(), k.id)]] = v
                     del thing[k]
                 else:
                     substitute(k)
         elif isinstance(thing, DictSerializable):
-            for k, v in vars(thing).items():
+            for k, v in vars(thing).copy().items():
                 if isinstance(thing, BaseEntity) and k in thing.skip:
                     continue
                 if isinstance(v, LinkByUID) and (v.scope.lower(), v.id) in index:
@@ -258,7 +260,7 @@ def _recursive_substitute(obj, native_uid=None, seen=None):
                 obj[i] = deepcopy(x)
                 _recursive_substitute(obj[i], native_uid, seen)
     elif isinstance(obj, dict):
-        for k, x in obj.items():
+        for k, x in obj.copy().items():
             if isinstance(x, BaseEntity):
                 if len(x.uids) == 0:
                     raise ValueError("No UID for {}".format(x))
@@ -269,7 +271,7 @@ def _recursive_substitute(obj, native_uid=None, seen=None):
                     obj[k] = LinkByUID(uid_to_use[0], uid_to_use[1])
             else:
                 _recursive_substitute(x, native_uid, seen)
-        for k, x in obj.items():
+        for k, x in obj.copy().items():
             if isinstance(k, BaseEntity):
                 if len(k.uids) == 0:
                     raise ValueError("No UID for {}".format(k))

--- a/taurus/util/impl.py
+++ b/taurus/util/impl.py
@@ -65,7 +65,7 @@ def substitute_objects(obj, index):
                 else:
                     substitute(x)
         elif isinstance(thing, dict):
-            # we are restricted from modifying the keys of a dict while iterating over it's
+            # we are restricted from modifying the keys of a dict while iterating over its
             # items so we iterate over a copy of the dict instead.
             for k, v in thing.copy().items():
                 if isinstance(v, LinkByUID) and (v.scope.lower(), v.id) in index:


### PR DESCRIPTION
This PR has two small commits.  One fixes a bug regarding mutating dictionary keys while iterating over it.  This operation raises an exception in newer versions of Python such as 3.8.0 and could output incorrect data.

The other commit uses thin_dumps when serializing DictSerializable objects.  This is required in order to use these objects with citrine-python, e.g. registering a Taurus ProcessSpec in a Dataset.  I suggest we create an integration test to make sure it's properly covered.

Please let me know if switching to thin_dumps might cause any unintended consequences.

This is based on the PR from @asantas93.