### PR TITLE
Bug in recursive foreach: it doesn't walk from process to ingredients

### DIFF
--- a/taurus/entity/object/__init__.py
+++ b/taurus/entity/object/__init__.py
@@ -5,3 +5,5 @@ from .process_run import ProcessRun
 from .material_spec import MaterialSpec
 from .measurement_spec import MeasurementSpec
 from .process_spec import ProcessSpec
+from .ingredient_run import IngredientRun
+from .ingredient_spec import IngredientSpec

--- a/taurus/entity/util.py
+++ b/taurus/entity/util.py
@@ -1,4 +1,5 @@
 """Utility methods."""
+from taurus.util import recursive_foreach
 
 
 def make_instance(base_spec):
@@ -104,31 +105,17 @@ def complete_material_history(mat):
         links substituted.
     """
     from taurus.entity.base_entity import BaseEntity
-    from taurus.entity.dict_serializable import DictSerializable
     import json
     from taurus.client.json_encoder import dumps, loads
     from taurus.util.impl import substitute_links
 
-    queue = [mat]
-    seen = set()
     result = []
 
-    while queue:
-        obj = queue.pop(0)
+    def body(obj: BaseEntity):
+        copy = loads(dumps(obj))
+        substitute_links(copy)
+        result.append(json.loads(dumps(copy))[0][0])
 
-        if isinstance(obj, BaseEntity):
-            if obj not in seen:
-                seen.add(obj)
-                queue.extend(obj.__dict__.values())
-
-                copy = loads(dumps(obj))
-                substitute_links(copy)
-                result.insert(0, json.loads(dumps(copy))[0][0])  # Leaf first
-        elif isinstance(obj, (list, tuple)):
-            queue.extend(obj)
-        elif isinstance(obj, dict):
-            queue.extend(obj.values())
-        elif isinstance(obj, DictSerializable):
-            queue.extend(obj.__dict__.values())
+    recursive_foreach(mat, body, apply_first=False)
 
     return result

--- a/taurus/util/impl.py
+++ b/taurus/util/impl.py
@@ -153,41 +153,40 @@ def recursive_foreach(obj, func, apply_first=False, seen=None):
         else:
             seen.add(obj)
 
+    if apply_first and isinstance(obj, BaseEntity):
+        func(obj)
+
     if isinstance(obj, (list, tuple)):
         for i, x in enumerate(obj):
             if isinstance(x, BaseEntity):
                 if apply_first:
-                    func(x)
                     recursive_foreach(x, func, apply_first, seen)
                 else:
                     recursive_foreach(x, func, apply_first, seen)
-                    func(x)
             else:
                 recursive_foreach(x, func, apply_first, seen)
     elif isinstance(obj, dict):
         for x in concatv(obj.keys(), obj.values()):
             if isinstance(x, BaseEntity):
                 if apply_first:
-                    func(x)
                     recursive_foreach(x, func, apply_first, seen)
                 else:
                     recursive_foreach(x, func, apply_first, seen)
-                    func(x)
             else:
                 recursive_foreach(x, func, apply_first, seen)
     elif isinstance(obj, DictSerializable):
         for k, x in obj.__dict__.items():
-            if isinstance(obj, BaseEntity) and k in obj.skip:
-                continue
             if isinstance(x, BaseEntity):
                 if apply_first:
-                    func(x)
                     recursive_foreach(x, func, apply_first, seen)
                 else:
                     recursive_foreach(x, func, apply_first, seen)
-                    func(x)
             else:
                 recursive_foreach(x, func, apply_first, seen)
+
+    if isinstance(obj, BaseEntity) and not apply_first:
+        func(obj)
+
     return
 
 

--- a/taurus/util/impl.py
+++ b/taurus/util/impl.py
@@ -139,6 +139,10 @@ def recursive_foreach(obj, func, apply_first=False, seen=None):
     """
     Apply a function recursively to each BaseEntity object.
 
+    Only objects of type BaseEntity will have the function applied, but the recursion will walk
+    through all objects.  For example, BaseEntity -> list -> BaseEntity will have func applied
+    to both base entities.
+
     :param obj: target of the operation
     :param func: to apply to each contained BaseEntity
     :param apply_first: whether to apply the func before applying it to members (default: false)
@@ -158,31 +162,13 @@ def recursive_foreach(obj, func, apply_first=False, seen=None):
 
     if isinstance(obj, (list, tuple)):
         for i, x in enumerate(obj):
-            if isinstance(x, BaseEntity):
-                if apply_first:
-                    recursive_foreach(x, func, apply_first, seen)
-                else:
-                    recursive_foreach(x, func, apply_first, seen)
-            else:
-                recursive_foreach(x, func, apply_first, seen)
+            recursive_foreach(x, func, apply_first, seen)
     elif isinstance(obj, dict):
         for x in concatv(obj.keys(), obj.values()):
-            if isinstance(x, BaseEntity):
-                if apply_first:
-                    recursive_foreach(x, func, apply_first, seen)
-                else:
-                    recursive_foreach(x, func, apply_first, seen)
-            else:
-                recursive_foreach(x, func, apply_first, seen)
+            recursive_foreach(x, func, apply_first, seen)
     elif isinstance(obj, DictSerializable):
         for k, x in obj.__dict__.items():
-            if isinstance(x, BaseEntity):
-                if apply_first:
-                    recursive_foreach(x, func, apply_first, seen)
-                else:
-                    recursive_foreach(x, func, apply_first, seen)
-            else:
-                recursive_foreach(x, func, apply_first, seen)
+            recursive_foreach(x, func, apply_first, seen)
 
     if isinstance(obj, BaseEntity) and not apply_first:
         func(obj)

--- a/taurus/util/tests/test_foreach.py
+++ b/taurus/util/tests/test_foreach.py
@@ -3,10 +3,10 @@ from taurus.util.impl import recursive_foreach
 
 
 def test_recursive_foreach():
-    """Test that recursive foreach will actually walk through a material history"""
+    """Test that recursive foreach will actually walk through a material history."""
     mat_run = MaterialRun("foo")
     process_run = ProcessRun("bar")
-    ingredient_run = IngredientRun(process=process_run, material=mat_run, name="foobar")
+    IngredientRun(process=process_run, material=mat_run, name="foobar")
     output = MaterialRun(process=process_run)
 
     types = []

--- a/taurus/util/tests/test_foreach.py
+++ b/taurus/util/tests/test_foreach.py
@@ -1,4 +1,8 @@
-from taurus.entity.object import ProcessRun, MaterialRun, IngredientRun
+from taurus.entity.attribute.property import Property
+from taurus.entity.bounds.real_bounds import RealBounds
+from taurus.entity.object import ProcessRun, MaterialRun, IngredientRun, MeasurementRun
+from taurus.entity.template.property_template import PropertyTemplate
+from taurus.entity.value.nominal_real import NominalReal
 from taurus.util.impl import recursive_foreach
 
 
@@ -9,7 +13,18 @@ def test_recursive_foreach():
     IngredientRun(process=process_run, material=mat_run, name="foobar")
     output = MaterialRun(process=process_run)
 
+    # property templates are trickier than templates because they are referenced in attributes
+    template = PropertyTemplate("prop", bounds=RealBounds(0, 1, ""))
+    prop = Property("prop", value=NominalReal(1.0, ""), template=template)
+    MeasurementRun("check", material=output, properties=prop)
+
     types = []
     recursive_foreach(output, lambda x: types.append(x.typ))
 
-    assert sorted(types) == ["ingredient_run", "material_run", "material_run", "process_run"]
+    expected = ["ingredient_run",
+                "material_run", "material_run",
+                "process_run",
+                "measurement_run",
+                "property_template"
+                ]
+    assert sorted(types) == sorted(expected)

--- a/taurus/util/tests/test_foreach.py
+++ b/taurus/util/tests/test_foreach.py
@@ -1,0 +1,15 @@
+from taurus.entity.object import ProcessRun, MaterialRun, IngredientRun
+from taurus.util.impl import recursive_foreach
+
+
+def test_recursive_foreach():
+    """Test that recursive foreach will actually walk through a material history"""
+    mat_run = MaterialRun("foo")
+    process_run = ProcessRun("bar")
+    ingredient_run = IngredientRun(process=process_run, material=mat_run, name="foobar")
+    output = MaterialRun(process=process_run)
+
+    types = []
+    recursive_foreach(output, lambda x: types.append(x.typ))
+
+    assert sorted(types) == ["ingredient_run", "material_run", "material_run", "process_run"]


### PR DESCRIPTION
This is just a reproduction step.  Fix to come.

Fix:
The seen set of object hashes should be enough to avoid cycles,
so we don't have to re-use the skip member from DictSerializable
(which conflated serialization and pointer concerns).

Also moved the applyFirst/applyLast logic out of those if statements
to prevent the first object in a cycle from having the function applied
to it twice.