### PR TITLE
Don't mutate original object in substitute_objects

### DIFF
--- a/taurus/client/json_encoder.py
+++ b/taurus/client/json_encoder.py
@@ -88,8 +88,8 @@ def loads(json_str, **kwargs):
     index = {}
     raw = json.loads(json_str, object_hook=lambda x: _loado(x, index), **kwargs)
     # the return value is in the 2nd position.
-    substitute_objects(raw, index)
-    return raw[1]
+    subbed = substitute_objects(raw, index)
+    return subbed[1]
 
 
 def load(fp, **kwargs):

--- a/taurus/entity/dict_serializable.py
+++ b/taurus/entity/dict_serializable.py
@@ -36,7 +36,7 @@ class DictSerializable(ABC):
         for name, arg in d.items():
             if name in expected_arg_names:
                 kwargs[name] = arg
-            else:
+            elif name != 'type':
                 logger.warning('Ignoring unexpected keyword argument in {}: {}'.format(
                     cls.__name__, name))
         # noinspection PyArgumentList

--- a/taurus/util/impl.py
+++ b/taurus/util/impl.py
@@ -48,32 +48,27 @@ def substitute_objects(obj, index):
     It is the inverse of substitute_links.
     :param obj: target of the operation
     :param index: containing the objects that the uids point to
-    :return: None
     """
     visited = {}
-
-    def index_or_obj(x):
-        if isinstance(x, LinkByUID):
-            return index.get((x.scope.lower(), x.id), x)
-        else:
-            return x
 
     def substitute(thing):
         if id(thing) in visited:
             return visited[id(thing)]
-        if isinstance(thing, list):
-            new = [substitute(index_or_obj(x)) for x in thing]
+        if isinstance(thing, LinkByUID):
+            o = index.get((thing.scope.lower(), thing.id), thing)
+            visited[id(thing)] = o
+            new = substitute(o)
+        elif isinstance(thing, list):
+            new = [substitute(x) for x in thing]
         elif isinstance(thing, tuple):
-            new = tuple(substitute(index_or_obj(x)) for x in thing)
+            new = tuple(substitute(x) for x in thing)
         elif isinstance(thing, dict):
-            new = {substitute(index_or_obj(k)): substitute(index_or_obj(v))
-                   for k, v in thing.items()}
+            new = {substitute(k): substitute(v) for k, v in thing.items()}
         elif isinstance(thing, DictSerializable):
-            new_attrs = {substitute(index_or_obj(k)): substitute(index_or_obj(v))
-                         for k, v in thing.as_dict().items()}
+            new_attrs = {substitute(k): substitute(v) for k, v in thing.as_dict().items()}
             new = thing.from_dict(new_attrs)
         else:
-            new = index_or_obj(thing)
+            new = thing
 
         visited[(id(new))] = new
         visited[(id(thing))] = new

--- a/taurus/util/tests/test_substitute_objects.py
+++ b/taurus/util/tests/test_substitute_objects.py
@@ -26,6 +26,7 @@ def test_dictionary_substitution():
 
 
 def test_tuple_sub():
+    """substitute_objects() should correctly substitute tuple values."""
     proc = ProcessRun('foo', uids={'id': '123'})
     proc_link = LinkByUID.from_entity(proc)
     index = {(proc_link.scope, proc_link.id): proc}

--- a/taurus/util/tests/test_substitute_objects.py
+++ b/taurus/util/tests/test_substitute_objects.py
@@ -25,6 +25,15 @@ def test_dictionary_substitution():
     assert v == mat
 
 
+def test_tuple_sub():
+    proc = ProcessRun('foo', uids={'id': '123'})
+    proc_link = LinkByUID.from_entity(proc)
+    index = {(proc_link.scope, proc_link.id): proc}
+    tup = (proc_link,)
+    subbed = substitute_objects(tup, index)
+    assert subbed[0] == proc
+
+
 def test_recursive_foreach():
     """Test that recursive_foreach() applies a method to every object."""
     new_tag = "Extra tag"

--- a/taurus/util/tests/test_substitute_objects.py
+++ b/taurus/util/tests/test_substitute_objects.py
@@ -19,8 +19,10 @@ def test_dictionary_substitution():
              (proc_link.scope.lower(), proc_link.id): proc}
 
     test_dict = {LinkByUID.from_entity(proc): LinkByUID.from_entity(mat)}
-    substitute_objects(test_dict, index)
-    assert test_dict[proc] == mat
+    subbed = substitute_objects(test_dict, index)
+    k, v = next((k, v) for k, v in subbed.items())
+    assert k == proc
+    assert v == mat
 
 
 def test_recursive_foreach():


### PR DESCRIPTION
This change is a step in the direction of a totally immutable JSON deserialization system. Right now, mutating JSON is leading to the need for calls to `deepcopy` in this project and in `citrine-python`. Deep copies are expensive and introduce noticeable latency (about a second in a recent example) for large JSON payloads such as in a material histories.