### PR TITLE
Reflect intent not to rename IngredientRuns

### DIFF
--- a/taurus/demo/cake.py
+++ b/taurus/demo/cake.py
@@ -637,7 +637,8 @@ def make_cake(seed=None, tmpl=None, cake_spec=None):
     queue = [cake]
     while queue:
         item = queue.pop(0)
-        item.name = item.name.replace('Abstract ', '').replace(', in General', '')
+        if not isinstance(item, IngredientRun):
+            item.name = item.name.replace('Abstract ', '').replace(', in General', '')
         if item.spec.tags is not None:
             item.tags = list(item.spec.tags)
         if item.spec.notes:  # None or empty string

--- a/taurus/demo/cake.py
+++ b/taurus/demo/cake.py
@@ -164,6 +164,18 @@ def make_cake_spec(tmpl=None):
     if tmpl is None:
         tmpl = make_cake_templates()
 
+    count = dict()
+
+    def ingredient_kwargs(material):
+        # Pulls the elements of a material that all ingredients consume out
+        count[material.name] = count.get(material.name, 0) + 1
+        return {
+            "name": "{} input{}".format(material.name.replace('Abstract ', ''),
+                                        " (Again)" * (count[material.name] - 1)),
+            "tags": list(material.tags),
+            "material": material
+        }
+
     ###############################################################################################
     # Objects
     cake = MaterialSpec(
@@ -215,12 +227,10 @@ def make_cake_spec(tmpl=None):
         notes='Chocolate frosting'
     )
     IngredientSpec(
-        name="{} input".format(frosting.name.replace('Abstract ', '')),
-        tags=list(frosting.tags),
+        **ingredient_kwargs(frosting),
         notes='Seems like a lot of frosting',
         labels=['coating'],
         process=cake.process,
-        material=frosting,
         absolute_quantity=NominalReal(nominal=0.751, units='kg')
     )
 
@@ -240,11 +250,9 @@ def make_cake_spec(tmpl=None):
         notes='The cakey part of the cake'
     )
     IngredientSpec(
-        name="{} input".format(baked_cake.name.replace('Abstract ', '')),
-        tags=list(baked_cake.tags),
+        **ingredient_kwargs(baked_cake),
         labels=['substrate'],
-        process=cake.process,
-        material=baked_cake
+        process=cake.process
     )
 
     ########################
@@ -264,11 +272,9 @@ def make_cake_spec(tmpl=None):
         notes='The fluid that converts to cake with heat'
     )
     IngredientSpec(
-        name="{} input".format(batter.name.replace('Abstract ', '')),
-        tags=list(batter.tags),
+        **ingredient_kwargs(batter),
         labels=['precursor'],
-        process=baked_cake.process,
-        material=batter
+        process=baked_cake.process
     )
 
     ########################
@@ -288,11 +294,9 @@ def make_cake_spec(tmpl=None):
         notes='The wet fraction of a batter'
     )
     IngredientSpec(
-        name="{} input".format(wetmix.name.replace('Abstract ', '')),
-        tags=list(wetmix.tags),
+        **ingredient_kwargs(wetmix),
         labels=['wet'],
-        process=batter.process,
-        material=wetmix
+        process=batter.process
     )
 
     drymix = MaterialSpec(
@@ -311,11 +315,9 @@ def make_cake_spec(tmpl=None):
         notes='The dry fraction of a batter'
     )
     IngredientSpec(
-        name="{} input".format(drymix.name.replace('Abstract ', '')),
-        tags=list(drymix.tags),
+        **ingredient_kwargs(drymix),
         labels=['dry'],
         process=batter.process,
-        material=drymix,
         absolute_quantity=NominalReal(nominal=3.052, units='cups')
     )
 
@@ -360,11 +362,9 @@ def make_cake_spec(tmpl=None):
         notes='All-purpose flour'
     )
     IngredientSpec(
-        name="{} input".format(flour.name.replace('Abstract ', '')),
-        tags=list(flour.tags),
+        **ingredient_kwargs(flour),
         labels=['dry'],
         process=drymix.process,
-        material=flour,
         volume_fraction=NominalReal(nominal=0.9829, units='')  # 3 cups
     )
 
@@ -384,11 +384,9 @@ def make_cake_spec(tmpl=None):
         notes='Leavening agent for cake'
     )
     IngredientSpec(
-        name="{} input".format(baking_powder.name.replace('Abstract ', '')),
-        tags=list(baking_powder.tags),
+        **ingredient_kwargs(baking_powder),
         labels=['leavening', 'dry'],
         process=drymix.process,
-        material=baking_powder,
         volume_fraction=NominalReal(nominal=0.0137, units='')  # 2 teaspoons
     )
 
@@ -411,11 +409,9 @@ def make_cake_spec(tmpl=None):
         ]
     )
     IngredientSpec(
-        name="{} input".format(salt.name.replace('Abstract ', '')),
-        tags=list(salt.tags),
+        **ingredient_kwargs(salt),
         labels=['dry', 'seasoning'],
         process=drymix.process,
-        material=salt,
         volume_fraction=NominalReal(nominal=0.0034, units='')  # 1/2 teaspoon
     )
 
@@ -438,11 +434,9 @@ def make_cake_spec(tmpl=None):
         ]
     )
     IngredientSpec(
-        name="{} input".format(sugar.name.replace('Abstract ', '')),
-        tags=list(sugar.tags),
+        **ingredient_kwargs(sugar),
         labels=['wet', 'sweetener'],
         process=wetmix.process,
-        material=sugar,
         absolute_quantity=NominalReal(nominal=2, units='cups')
     )
 
@@ -462,19 +456,15 @@ def make_cake_spec(tmpl=None):
         notes='Shortening for making rich, buttery baked goods'
     )
     IngredientSpec(
-        name="{} input".format(butter.name.replace('Abstract ', '')),
-        tags=list(butter.tags),
+        **ingredient_kwargs(butter),
         labels=['wet', 'shortening'],
         process=wetmix.process,
-        material=butter,
         absolute_quantity=NominalReal(nominal=1, units='cups')
     )
     IngredientSpec(
-        name="{} input".format(butter.name.replace('Abstract ', '')),
-        tags=list(butter.tags),
+        **ingredient_kwargs(butter),
         labels=['shortening'],
         process=frosting.process,
-        material=butter,
         mass_fraction=NominalReal(nominal=0.1434, units='')  # 1/2 c @ 0.911 g/cc
     )
 
@@ -494,11 +484,8 @@ def make_cake_spec(tmpl=None):
         notes=''
     )
     IngredientSpec(
-        name="{} input".format(eggs.name.replace('Abstract ', '')),
-        tags=list(eggs.tags),
+        **ingredient_kwargs(eggs),
         labels=['wet'],
-        process=wetmix.process,
-        material=eggs,
         absolute_quantity=NominalReal(nominal=4, units='')
     )
 
@@ -518,19 +505,15 @@ def make_cake_spec(tmpl=None):
         notes=''
     )
     IngredientSpec(
-        name="{} input".format(vanilla.name.replace('Abstract ', '')),
-        tags=list(vanilla.tags),
+        **ingredient_kwargs(vanilla),
         labels=['wet', 'flavoring'],
         process=wetmix.process,
-        material=vanilla,
         absolute_quantity=NominalReal(nominal=2, units='teaspoons')
     )
     IngredientSpec(
-        name="{} input".format(vanilla.name.replace('Abstract ', '')),
-        tags=list(vanilla.tags),
+        **ingredient_kwargs(vanilla),
         labels=['flavoring'],
         process=frosting.process,
-        material=vanilla,
         mass_fraction=NominalReal(nominal=0.0231, units='')  # 2 tsp @ 0.879 g/cc
     )
 
@@ -550,19 +533,15 @@ def make_cake_spec(tmpl=None):
         notes=''
     )
     IngredientSpec(
-        name="{} input".format(milk.name.replace('Abstract ', '')),
-        tags=list(milk.tags),
+        **ingredient_kwargs(milk),
         labels=['wet'],
         process=batter.process,
-        material=milk,
         absolute_quantity=NominalReal(nominal=1, units='cup')
     )
     IngredientSpec(
-        name="{} input".format(milk.name.replace('Abstract ', '')),
-        tags=list(milk.tags),
+        **ingredient_kwargs(milk),
         labels=[],
         process=frosting.process,
-        material=milk,
         mass_fraction=NominalReal(nominal=0.0816, units='')  # 1/4 c @ 1.037 g/cc
     )
 
@@ -582,11 +561,9 @@ def make_cake_spec(tmpl=None):
         notes=''
     )
     IngredientSpec(
-        name="{} input".format(chocolate.name.replace('Abstract ', '')),
-        tags=list(chocolate.tags),
+        **ingredient_kwargs(chocolate),
         labels=['flavoring'],
         process=frosting.process,
-        material=chocolate,
         mass_fraction=NominalReal(nominal=0.1132, units='')  # 3 oz.
     )
 
@@ -606,11 +583,9 @@ def make_cake_spec(tmpl=None):
         notes='Granulated sugar mixed with corn starch'
     )
     IngredientSpec(
-        name="{} input".format(powder_sugar.name.replace('Abstract ', '')),
-        tags=list(powder_sugar.tags),
+        **ingredient_kwargs(powder_sugar),
         labels=['flavoring'],
         process=frosting.process,
-        material=powder_sugar,
         mass_fraction=NominalReal(nominal=0.6387, units='')  # 4 c @ 30 g/ 0.25 cups
     )
     return cake

--- a/taurus/demo/cake.py
+++ b/taurus/demo/cake.py
@@ -215,7 +215,7 @@ def make_cake_spec(tmpl=None):
         notes='Chocolate frosting'
     )
     IngredientSpec(
-        name="{} input".format(frosting.name),
+        name="{} input".format(frosting.name.replace('Abstract ', '')),
         tags=list(frosting.tags),
         notes='Seems like a lot of frosting',
         labels=['coating'],
@@ -240,7 +240,7 @@ def make_cake_spec(tmpl=None):
         notes='The cakey part of the cake'
     )
     IngredientSpec(
-        name="{} input".format(baked_cake.name),
+        name="{} input".format(baked_cake.name.replace('Abstract ', '')),
         tags=list(baked_cake.tags),
         labels=['substrate'],
         process=cake.process,
@@ -264,7 +264,7 @@ def make_cake_spec(tmpl=None):
         notes='The fluid that converts to cake with heat'
     )
     IngredientSpec(
-        name="{} input".format(batter.name),
+        name="{} input".format(batter.name.replace('Abstract ', '')),
         tags=list(batter.tags),
         labels=['precursor'],
         process=baked_cake.process,
@@ -288,7 +288,7 @@ def make_cake_spec(tmpl=None):
         notes='The wet fraction of a batter'
     )
     IngredientSpec(
-        name="{} input".format(wetmix.name),
+        name="{} input".format(wetmix.name.replace('Abstract ', '')),
         tags=list(wetmix.tags),
         labels=['wet'],
         process=batter.process,
@@ -311,7 +311,7 @@ def make_cake_spec(tmpl=None):
         notes='The dry fraction of a batter'
     )
     IngredientSpec(
-        name="{} input".format(drymix.name),
+        name="{} input".format(drymix.name.replace('Abstract ', '')),
         tags=list(drymix.tags),
         labels=['dry'],
         process=batter.process,
@@ -360,7 +360,7 @@ def make_cake_spec(tmpl=None):
         notes='All-purpose flour'
     )
     IngredientSpec(
-        name="{} input".format(flour.name),
+        name="{} input".format(flour.name.replace('Abstract ', '')),
         tags=list(flour.tags),
         labels=['dry'],
         process=drymix.process,
@@ -384,7 +384,7 @@ def make_cake_spec(tmpl=None):
         notes='Leavening agent for cake'
     )
     IngredientSpec(
-        name="{} input".format(baking_powder.name),
+        name="{} input".format(baking_powder.name.replace('Abstract ', '')),
         tags=list(baking_powder.tags),
         labels=['leavening', 'dry'],
         process=drymix.process,
@@ -411,7 +411,7 @@ def make_cake_spec(tmpl=None):
         ]
     )
     IngredientSpec(
-        name="{} input".format(salt.name),
+        name="{} input".format(salt.name.replace('Abstract ', '')),
         tags=list(salt.tags),
         labels=['dry', 'seasoning'],
         process=drymix.process,
@@ -438,7 +438,7 @@ def make_cake_spec(tmpl=None):
         ]
     )
     IngredientSpec(
-        name="{} input".format(sugar.name),
+        name="{} input".format(sugar.name.replace('Abstract ', '')),
         tags=list(sugar.tags),
         labels=['wet', 'sweetener'],
         process=wetmix.process,
@@ -462,7 +462,7 @@ def make_cake_spec(tmpl=None):
         notes='Shortening for making rich, buttery baked goods'
     )
     IngredientSpec(
-        name="{} input".format(butter.name),
+        name="{} input".format(butter.name.replace('Abstract ', '')),
         tags=list(butter.tags),
         labels=['wet', 'shortening'],
         process=wetmix.process,
@@ -470,7 +470,7 @@ def make_cake_spec(tmpl=None):
         absolute_quantity=NominalReal(nominal=1, units='cups')
     )
     IngredientSpec(
-        name="{} input".format(butter.name),
+        name="{} input".format(butter.name.replace('Abstract ', '')),
         tags=list(butter.tags),
         labels=['shortening'],
         process=frosting.process,
@@ -494,7 +494,7 @@ def make_cake_spec(tmpl=None):
         notes=''
     )
     IngredientSpec(
-        name="{} input".format(eggs.name),
+        name="{} input".format(eggs.name.replace('Abstract ', '')),
         tags=list(eggs.tags),
         labels=['wet'],
         process=wetmix.process,
@@ -518,7 +518,7 @@ def make_cake_spec(tmpl=None):
         notes=''
     )
     IngredientSpec(
-        name="{} input".format(vanilla.name),
+        name="{} input".format(vanilla.name.replace('Abstract ', '')),
         tags=list(vanilla.tags),
         labels=['wet', 'flavoring'],
         process=wetmix.process,
@@ -526,7 +526,7 @@ def make_cake_spec(tmpl=None):
         absolute_quantity=NominalReal(nominal=2, units='teaspoons')
     )
     IngredientSpec(
-        name="{} input".format(vanilla.name),
+        name="{} input".format(vanilla.name.replace('Abstract ', '')),
         tags=list(vanilla.tags),
         labels=['flavoring'],
         process=frosting.process,
@@ -550,7 +550,7 @@ def make_cake_spec(tmpl=None):
         notes=''
     )
     IngredientSpec(
-        name="{} input".format(milk.name),
+        name="{} input".format(milk.name.replace('Abstract ', '')),
         tags=list(milk.tags),
         labels=['wet'],
         process=batter.process,
@@ -558,7 +558,7 @@ def make_cake_spec(tmpl=None):
         absolute_quantity=NominalReal(nominal=1, units='cup')
     )
     IngredientSpec(
-        name="{} input".format(milk.name),
+        name="{} input".format(milk.name.replace('Abstract ', '')),
         tags=list(milk.tags),
         labels=[],
         process=frosting.process,
@@ -582,7 +582,7 @@ def make_cake_spec(tmpl=None):
         notes=''
     )
     IngredientSpec(
-        name="{} input".format(chocolate.name),
+        name="{} input".format(chocolate.name.replace('Abstract ', '')),
         tags=list(chocolate.tags),
         labels=['flavoring'],
         process=frosting.process,
@@ -606,7 +606,7 @@ def make_cake_spec(tmpl=None):
         notes='Granulated sugar mixed with corn starch'
     )
     IngredientSpec(
-        name="{} input".format(powder_sugar.name),
+        name="{} input".format(powder_sugar.name.replace('Abstract ', '')),
         tags=list(powder_sugar.tags),
         labels=['flavoring'],
         process=frosting.process,
@@ -637,8 +637,7 @@ def make_cake(seed=None, tmpl=None, cake_spec=None):
     queue = [cake]
     while queue:
         item = queue.pop(0)
-        if not isinstance(item, IngredientRun):
-            item.name = item.name.replace('Abstract ', '').replace(', in General', '')
+        item.name = item.name.replace('Abstract ', '').replace(', in General', '')
         if item.spec.tags is not None:
             item.tags = list(item.spec.tags)
         if item.spec.notes:  # None or empty string

--- a/taurus/demo/cake.py
+++ b/taurus/demo/cake.py
@@ -637,15 +637,16 @@ def make_cake(seed=None, tmpl=None, cake_spec=None):
     queue = [cake]
     while queue:
         item = queue.pop(0)
-        item.name = item.name.replace('Abstract ', '').replace(', in General', '')
         if item.spec.tags is not None:
             item.tags = list(item.spec.tags)
         if item.spec.notes:  # None or empty string
             item.notes = 'The spec says "{}"'.format(item.spec.notes)
 
         if isinstance(item, MaterialRun):
+            item.name = item.name.replace('Abstract ', '')
             queue.append(item.process)
         elif isinstance(item, ProcessRun):
+            item.name = item.name.replace(', in General', '')
             queue.extend(item.ingredients)
             if item.template.name == "Procurement":
                 item.source = PerformedSource(performed_by='hamilton',

--- a/taurus/entity/object/ingredient_run.py
+++ b/taurus/entity/object/ingredient_run.py
@@ -12,25 +12,6 @@ class IngredientRun(BaseObject, HasQuantities):
 
     Ingredients annotate a material with information about its usage in a process.
 
-    *  If a user invokes the IngredientRun constructor in citrine-python with either the name
-       or labels argument, a deprecation warning will be issued
-
-    * If a user invokes the spec setter on an IngredientRun and the value is an IngredientSpec
-      (as opposed to a LinkByUID), the `name` and `labels` fields will be set to `spec.name`
-      and `spec.labels`, respectively
-
-        * This is also true with the spec argument to the IngredientRun constructor - the spec
-          setter is called by the constructor
-
-    * If a user attempts to register an IngredientRun whose name or labels do not match those of
-      its spec, a validation error (HTTP 400) will be returned
-
-        * This includes if the values are None, so users should explicitly set their spec to be
-          the appropriate IngredientSpec and not just a LinkByUID
-
-    * Any attempt to update the name or labels of an IngredientSpec that is referenced by 1 or
-      more IngredientRuns will return a validation error (HTTP 400)
-
     Parameters
     ----------
     uids: Map[str, str], optional

--- a/taurus/entity/object/ingredient_run.py
+++ b/taurus/entity/object/ingredient_run.py
@@ -12,6 +12,25 @@ class IngredientRun(BaseObject, HasQuantities):
 
     Ingredients annotate a material with information about its usage in a process.
 
+    *  If a user invokes the IngredientRun constructor in citrine-python with either the name
+       or labels argument, a deprecation warning will be issued
+
+    * If a user invokes the spec setter on an IngredientRun and the value is an IngredientSpec
+      (as opposed to a LinkByUID), the `name` and `labels` fields will be set to `spec.name`
+      and `spec.labels`, respectively
+
+        * This is also true with the spec argument to the IngredientRun constructor - the spec
+          setter is called by the constructor
+
+    * If a user attempts to register an IngredientRun whose name or labels do not match those of
+      its spec, a validation error (HTTP 400) will be returned
+
+        * This includes if the values are None, so users should explicitly set their spec to be
+          the appropriate IngredientSpec and not just a LinkByUID
+
+    * Any attempt to update the name or labels of an IngredientSpec that is referenced by 1 or
+      more IngredientRuns will return a validation error (HTTP 400)
+
     Parameters
     ----------
     uids: Map[str, str], optional


### PR DESCRIPTION
@ventura-rivera pointed out that this line was leading to misalignment of ingredient run and spec names in nextgen-devkit. This behavior was not observed in the dumped taurus cake example you get with `python taurus/demo/cake.py` because of [a call to loads](https://github.com/CitrineInformatics/taurus/blob/092feb89cad3d97bcf04549504cd75d7303cff18/taurus/entity/util.py#L115), which overwrites the `name` and `labels` again when `spec` is populated.