### PR TITLE
Bug/PLA-2252 nominal composition as dictionary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,6 +49,7 @@ coverage.xml
 *.cover
 .hypothesis/
 .pytest_cache/
+flex_measurements.json
 
 # Translations
 *.mo

--- a/taurus/entity/value/nominal_composition.py
+++ b/taurus/entity/value/nominal_composition.py
@@ -42,4 +42,3 @@ class NominalComposition(CompositionValue):
             self._quantities = dict(quantities)
         else:
             raise TypeError("quantities must be dict or List of two-item lists or None")
-

--- a/taurus/entity/value/nominal_composition.py
+++ b/taurus/entity/value/nominal_composition.py
@@ -43,13 +43,3 @@ class NominalComposition(CompositionValue):
         else:
             raise TypeError("quantities must be dict or List of two-item lists or None")
 
-    def as_dict(self):
-        """
-        Convert the composition to a dictionary.
-
-        Overrides the ordinary
-        :func:`as_dict() <taurus.entity.dict_serializable.DictSerializable.as_dict>` method in
-        that the `quantities` field is turned into a list of lists,
-        each of which has the form [component, quantity].
-        """
-        return {"type": self.typ, "quantities": list(list(x) for x in self.quantities.items())}

--- a/taurus/entity/value/tests/test_nominal_composition.py
+++ b/taurus/entity/value/tests/test_nominal_composition.py
@@ -18,4 +18,3 @@ def test_invalid_assignment():
     """Test that invalid assignment produces a TypeError."""
     with pytest.raises(TypeError):
         NominalComposition(("a quantity", 55))
-        

--- a/taurus/entity/value/tests/test_nominal_composition.py
+++ b/taurus/entity/value/tests/test_nominal_composition.py
@@ -19,9 +19,3 @@ def test_invalid_assignment():
     with pytest.raises(TypeError):
         NominalComposition(("a quantity", 55))
 
-
-def test_quantities_as_dict():
-    """Test that the as_dict() method represents `quantities` as a list."""
-    test_composition = NominalComposition(dict(acetone=0.25, methanol=0.75))
-    quantities = test_composition.as_dict().get('quantities')
-    assert isinstance(quantities, list) and len(quantities) == 2

--- a/taurus/entity/value/tests/test_nominal_composition.py
+++ b/taurus/entity/value/tests/test_nominal_composition.py
@@ -18,3 +18,4 @@ def test_invalid_assignment():
     """Test that invalid assignment produces a TypeError."""
     with pytest.raises(TypeError):
         NominalComposition(("a quantity", 55))
+        

--- a/taurus/entity/value/tests/test_nominal_composition.py
+++ b/taurus/entity/value/tests/test_nominal_composition.py
@@ -18,4 +18,3 @@ def test_invalid_assignment():
     """Test that invalid assignment produces a TypeError."""
     with pytest.raises(TypeError):
         NominalComposition(("a quantity", 55))
-


### PR DESCRIPTION
## [Composition representation doesn't follow spec](https://citrine.atlassian.net/browse/PLA-2252)

We were generating an array to represent nominal_composition pairs. This is not to spec. This PR removes that transformation, maintaining the dictionary.