### PR TITLE
Add cake template, uid namespaces, improve testing

### DIFF
--- a/taurus/demo/cake.py
+++ b/taurus/demo/cake.py
@@ -191,7 +191,7 @@ def make_cake_spec(tmpl=None):
         name="Abstract Cake",
         template=tmpl["Dessert"],
         process=ProcessSpec(
-            name='Icing, in General',
+            name='Icing Cake, in General',
             template=tmpl["Icing"],
             tags=[
                 'spreading'
@@ -778,6 +778,35 @@ def make_cake(seed=None, tmpl=None, cake_spec=None):
 
 if __name__ == "__main__":
     cake = make_cake(seed=42)
+
+    queue = [cake]
+    seen = set()
+    id_seen = set()
+    while queue:
+        item = queue.pop(0)
+        if item is None or id(item) in id_seen:
+            continue
+        id_seen.add(id(item))
+
+        # for scope in item.uids:
+        #     if item.uids[scope] in seen:
+        #         print(scope, item.uids[scope], item.name)
+        #     seen.add(item.uids[scope])
+        if item.name in seen:
+            print(item.name)
+        seen.add(item.name)
+
+        if isinstance(item, (MaterialRun, MeasurementRun, ProcessRun, IngredientRun)):
+            queue.append(item.spec)
+        if isinstance(item, (MaterialSpec, MeasurementSpec, ProcessSpec)):
+            queue.append(item.template)
+        if isinstance(item, MaterialRun):
+            queue.append(item.process)
+            queue.extend(item.measurements)
+        if isinstance(item, ProcessRun):
+            queue.extend(item.ingredients)
+        if isinstance(item, IngredientRun):
+            queue.append(item.material)
 
     with open("example_taurus_material_history.json", "w") as f:
         context_list = complete_material_history(cake)

--- a/taurus/demo/cake.py
+++ b/taurus/demo/cake.py
@@ -173,9 +173,7 @@ def make_cake_templates():
                                           description="Buyin' stuff")
 
     for key in tmpl:
-        tmpl[key].add_uid(DEMO_SCOPE, key + "-template")  # Hack to fix collisions
-        # TDOO: This should really be done in a new scope and with reasonable names, but
-        # time constraint
+        tmpl[key].add_uid(DEMO_SCOPE + "-template", key)
     return tmpl
 
 

--- a/taurus/demo/tests/test_cake.py
+++ b/taurus/demo/tests/test_cake.py
@@ -17,7 +17,23 @@ from taurus.entity.util import complete_material_history
 def test_cake():
     """Create cake, serialize, deserialize."""
     cake = make_cake()
-    assert dumps(loads(dumps(cake)), indent=2) == dumps(cake, indent=2)
+
+    def test_for_loss(obj):
+        if obj.name == "Baking doneness":
+            return  # TODO figure out why this case is failing
+        if obj != loads(dumps(obj)):
+            print(dumps(obj, indent=2))
+        assert(obj == loads(dumps(obj)))
+    recursive_foreach(cake, test_for_loss)
+
+    # And verify equality was working in the first place
+    cake2 = loads(dumps(cake))
+    cake2.name = "It's a trap!"
+    assert(cake2 != cake)
+    cake2.name = cake.name
+    assert(cake == cake2)
+    cake2.uids['new'] = "It's a trap!"
+    assert(cake2 != cake)
 
     # Check that all the objects show up
     tot_count = 0

--- a/taurus/demo/tests/test_cake.py
+++ b/taurus/demo/tests/test_cake.py
@@ -19,9 +19,11 @@ def test_cake():
     cake = make_cake()
 
     def test_for_loss(obj):
-        if obj.name == "Baking doneness":
-            return  # TODO figure out why this case is failing
-        assert(obj == loads(dumps(obj)))
+        mirror = loads(dumps(obj))
+
+        if obj.name in ("Baking doneness", "Abstract Flour", "Flour input", "Flour"):
+            return  # TODO figure out why these cases are failing
+        assert(obj == mirror)
     recursive_foreach(cake, test_for_loss)
 
     # And verify equality was working in the first place

--- a/taurus/demo/tests/test_cake.py
+++ b/taurus/demo/tests/test_cake.py
@@ -21,8 +21,6 @@ def test_cake():
     def test_for_loss(obj):
         if obj.name == "Baking doneness":
             return  # TODO figure out why this case is failing
-        if obj != loads(dumps(obj)):
-            print(dumps(obj, indent=2))
         assert(obj == loads(dumps(obj)))
     recursive_foreach(cake, test_for_loss)
 

--- a/taurus/demo/tests/test_cake.py
+++ b/taurus/demo/tests/test_cake.py
@@ -19,11 +19,7 @@ def test_cake():
     cake = make_cake()
 
     def test_for_loss(obj):
-        mirror = loads(dumps(obj))
-
-        if obj.name in ("Baking doneness", "Abstract Flour", "Flour input", "Flour"):
-            return  # TODO figure out why these cases are failing
-        assert(obj == mirror)
+        assert(obj == loads(dumps(obj)))
     recursive_foreach(cake, test_for_loss)
 
     # And verify equality was working in the first place

--- a/taurus/entity/value/base_value.py
+++ b/taurus/entity/value/base_value.py
@@ -12,12 +12,3 @@ class BaseValue(DictSerializable):
     """
 
     typ = "value"
-
-    def __repr__(self):
-        return str(self.as_dict())
-
-    def __eq__(self, other):
-        if isinstance(other, BaseValue):
-            return self.__repr__() == other.__repr__()
-        else:
-            return False

--- a/taurus/entity/value/base_value.py
+++ b/taurus/entity/value/base_value.py
@@ -12,4 +12,3 @@ class BaseValue(DictSerializable):
     """
 
     typ = "value"
-


### PR DESCRIPTION
In this update:
* Templates are added for elements with EmpiricalFormula values
* The UID namespace in broken into one for templates and one for objects
* The testing approach is improved
    * The testing had been sensitive to random choice of which UID scope was used in serialization