### PR TITLE
Added JPG to manifest (bug)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(name='taurus-citrine',
       package_data={
           'taurus': [
               'demo/strehlow_and_cook.json',
+              'demo/toothpick.jpg',
               'units/citrine_en.txt',
               'units/constants_en.txt'
           ]


### PR DESCRIPTION
A package file (toothpick.jpg) was not included in the setup.py file, and so wasn't being installed.