### PR TITLE
Added measurement parameters to example

### DIFF
--- a/taurus/demo/cake.py
+++ b/taurus/demo/cake.py
@@ -118,15 +118,15 @@ def make_cake_templates():
             ]
         )
     )
-    tmpl["Sample Size"] = ConditionTemplate(
-        name="Sample Size",
+    tmpl["Sample Mass"] = ConditionTemplate(
+        name="Sample Mass",
         description="Sample size in mass units, to go along with FDA Nutrition Facts",
-        bounds=RealBounds(1.e-3, 10.e3, "g")
+        bounds=RealBounds(1.e-3, 1.e4, "g")
     )
-    tmpl["Expected Sample Size"] = ParameterTemplate(
-        name="Expected Sample Size",
+    tmpl["Expected Sample Mass"] = ParameterTemplate(
+        name="Expected Sample Mass",
         description="Specified sample size in mass units, to go along with FDA Nutrition Facts",
-        bounds=RealBounds(1.e-3, 10.e3, "g")
+        bounds=RealBounds(1.e-3, 1.e4, "g")
     )
     tmpl["Chemical Formula"] = PropertyTemplate(
         name="Chemical Formula",
@@ -157,14 +157,14 @@ def make_cake_templates():
     tmpl["Nutritional Analysis"] = MeasurementTemplate(
         name="Nutritional Analysis",
         properties=[tmpl["Nutritional Information"]],
-        conditions=[tmpl["Sample Size"]],
-        parameters=[tmpl["Expected Sample Size"]]
+        conditions=[tmpl["Sample Mass"]],
+        parameters=[tmpl["Expected Sample Mass"]]
     )
     tmpl["Elemental Analysis"] = MeasurementTemplate(
         name="Elemental Analysis",
         properties=[tmpl["Chemical Formula"]],
-        conditions=[tmpl["Sample Size"]],
-        parameters=[tmpl["Expected Sample Size"]]
+        conditions=[tmpl["Sample Mass"]],
+        parameters=[tmpl["Expected Sample Mass"]]
     )
 
     tmpl["Dessert"] = MaterialTemplate(
@@ -390,7 +390,7 @@ def make_cake_spec(tmpl=None):
                 conditions=Condition(
                     name="Serving Size",
                     value=NominalReal(30, 'g'),
-                    template=tmpl["Sample Size"],
+                    template=tmpl["Sample Mass"],
                     origin="specified"
                 )
             )
@@ -818,34 +818,34 @@ def make_cake(seed=None, tmpl=None, cake_spec=None):
         origin="measured"
     ))
     flour_content.conditions.append(Condition(
-        name='Sample Size',
+        name='Sample Mass',
         value=NormalReal(
             mean=99 + 2 * random.random(),
             std=1.5,
             units='mg'
         ),
-        template=tmpl["Sample Size"],
+        template=tmpl["Sample Mass"],
         origin="measured"
     ))
     flour_content.parameters.append(Parameter(
-        name='Expected Sample Size',
+        name='Expected Sample Mass',
         value=NominalReal(nominal=0.1, units='g'),
-        template=tmpl["Expected Sample Size"],
+        template=tmpl["Expected Sample Mass"],
         origin="specified"
     ))
     flour_content.spec.conditions.append(Condition(
-        name='Sample Size',
+        name='Sample Mass',
         value=NominalReal(
             nominal=100,
             units='mg'
         ),
-        template=tmpl["Sample Size"],
+        template=tmpl["Sample Mass"],
         origin="specified"
     ))
     flour_content.spec.parameters.append(Parameter(
-        name='Expected Sample Size',
+        name='Expected Sample Mass',
         value=NominalReal(nominal=0.1, units='g'),
-        template=tmpl["Expected Sample Size"],
+        template=tmpl["Expected Sample Mass"],
         origin="specified"
     ))
 
@@ -856,28 +856,28 @@ def make_cake(seed=None, tmpl=None, cake_spec=None):
         origin="measured"
     ))
     salt_content.conditions.append(Condition(
-        name='Sample Size',
+        name='Sample Mass',
         value=NormalReal(
             mean=99 + 2 * random.random(),
             std=1.5,
             units='mg'
         ),
-        template=tmpl["Sample Size"],
+        template=tmpl["Sample Mass"],
         origin="measured"
     ))
     salt_content.parameters.append(Parameter(
-        name='Expected Sample Size',
+        name='Expected Sample Mass',
         value=NominalReal(nominal=0.1, units='g'),
-        template=tmpl["Expected Sample Size"],
+        template=tmpl["Expected Sample Mass"],
         origin="specified"
     ))
     salt_content.spec.conditions.append(Condition(
-        name='Sample Size',
+        name='Sample Mass',
         value=NominalReal(
             nominal=100,
             units='mg'
         ),
-        template=tmpl["Sample Size"],
+        template=tmpl["Sample Mass"],
         origin="specified"
     ))
 
@@ -888,19 +888,19 @@ def make_cake(seed=None, tmpl=None, cake_spec=None):
         origin="measured"
     ))
     sugar_content.conditions.append(Condition(
-        name='Sample Size',
+        name='Sample Mass',
         value=NormalReal(
             mean=99 + 2 * random.random(),
             std=1.5,
             units='mg'
         ),
-        template=tmpl["Sample Size"],
+        template=tmpl["Sample Mass"],
         origin="measured"
     ))
     sugar_content.spec.parameters.append(Parameter(
-        name='Expected Sample Size',
+        name='Expected Sample Mass',
         value=NominalReal(nominal=0.1, units='g'),
-        template=tmpl["Expected Sample Size"],
+        template=tmpl["Expected Sample Mass"],
         origin="specified"
     ))
 

--- a/taurus/demo/cake.py
+++ b/taurus/demo/cake.py
@@ -123,6 +123,11 @@ def make_cake_templates():
         description="Sample size in mass units, to go along with FDA Nutrition Facts",
         bounds=RealBounds(1.e-3, 10.e3, "g")
     )
+    tmpl["Expected Sample Size"] = ParameterTemplate(
+        name="Expected Sample Size",
+        description="Specified sample size in mass units, to go along with FDA Nutrition Facts",
+        bounds=RealBounds(1.e-3, 10.e3, "g")
+    )
     tmpl["Chemical Formula"] = PropertyTemplate(
         name="Chemical Formula",
         description="The chemical formula of a material",
@@ -152,12 +157,14 @@ def make_cake_templates():
     tmpl["Nutritional Analysis"] = MeasurementTemplate(
         name="Nutritional Analysis",
         properties=[tmpl["Nutritional Information"]],
-        conditions=[tmpl["Sample Size"]]
+        conditions=[tmpl["Sample Size"]],
+        parameters=[tmpl["Expected Sample Size"]]
     )
     tmpl["Elemental Analysis"] = MeasurementTemplate(
         name="Elemental Analysis",
         properties=[tmpl["Chemical Formula"]],
-        conditions=[tmpl["Sample Size"]]
+        conditions=[tmpl["Sample Size"]],
+        parameters=[tmpl["Expected Sample Size"]]
     )
 
     tmpl["Dessert"] = MaterialTemplate(
@@ -820,6 +827,12 @@ def make_cake(seed=None, tmpl=None, cake_spec=None):
         template=tmpl["Sample Size"],
         origin="measured"
     ))
+    flour_content.parameters.append(Parameter(
+        name='Sample Size',
+        value=NominalReal(nominal=0.1, units='g'),
+        template=tmpl["Sample Size"],
+        origin="measured"
+    ))
     flour_content.spec.conditions.append(Condition(
         name='Sample Size',
         value=NominalReal(
@@ -828,6 +841,12 @@ def make_cake(seed=None, tmpl=None, cake_spec=None):
         ),
         template=tmpl["Sample Size"],
         origin="specified"
+    ))
+    flour_content.spec.parameters.append(Parameter(
+        name='Sample Size',
+        value=NominalReal(nominal=0.1, units='g'),
+        template=tmpl["Sample Size"],
+        origin="measured"
     ))
 
     salt_content.properties.append(Property(
@@ -843,6 +862,12 @@ def make_cake(seed=None, tmpl=None, cake_spec=None):
             std=1.5,
             units='mg'
         ),
+        template=tmpl["Sample Size"],
+        origin="measured"
+    ))
+    salt_content.parameters.append(Parameter(
+        name='Sample Size',
+        value=NominalReal(nominal=0.1, units='g'),
         template=tmpl["Sample Size"],
         origin="measured"
     ))
@@ -869,6 +894,12 @@ def make_cake(seed=None, tmpl=None, cake_spec=None):
             std=1.5,
             units='mg'
         ),
+        template=tmpl["Sample Size"],
+        origin="measured"
+    ))
+    sugar_content.spec.parameters.append(Parameter(
+        name='Sample Size',
+        value=NominalReal(nominal=0.1, units='g'),
         template=tmpl["Sample Size"],
         origin="measured"
     ))

--- a/taurus/demo/cake.py
+++ b/taurus/demo/cake.py
@@ -828,10 +828,10 @@ def make_cake(seed=None, tmpl=None, cake_spec=None):
         origin="measured"
     ))
     flour_content.parameters.append(Parameter(
-        name='Sample Size',
+        name='Expected Sample Size',
         value=NominalReal(nominal=0.1, units='g'),
-        template=tmpl["Sample Size"],
-        origin="measured"
+        template=tmpl["Expected Sample Size"],
+        origin="specified"
     ))
     flour_content.spec.conditions.append(Condition(
         name='Sample Size',
@@ -843,10 +843,10 @@ def make_cake(seed=None, tmpl=None, cake_spec=None):
         origin="specified"
     ))
     flour_content.spec.parameters.append(Parameter(
-        name='Sample Size',
+        name='Expected Sample Size',
         value=NominalReal(nominal=0.1, units='g'),
-        template=tmpl["Sample Size"],
-        origin="measured"
+        template=tmpl["Expected Sample Size"],
+        origin="specified"
     ))
 
     salt_content.properties.append(Property(
@@ -866,10 +866,10 @@ def make_cake(seed=None, tmpl=None, cake_spec=None):
         origin="measured"
     ))
     salt_content.parameters.append(Parameter(
-        name='Sample Size',
+        name='Expected Sample Size',
         value=NominalReal(nominal=0.1, units='g'),
-        template=tmpl["Sample Size"],
-        origin="measured"
+        template=tmpl["Expected Sample Size"],
+        origin="specified"
     ))
     salt_content.spec.conditions.append(Condition(
         name='Sample Size',
@@ -898,10 +898,10 @@ def make_cake(seed=None, tmpl=None, cake_spec=None):
         origin="measured"
     ))
     sugar_content.spec.parameters.append(Parameter(
-        name='Sample Size',
+        name='Expected Sample Size',
         value=NominalReal(nominal=0.1, units='g'),
-        template=tmpl["Sample Size"],
-        origin="measured"
+        template=tmpl["Expected Sample Size"],
+        origin="specified"
     ))
 
     # Code to generate quasi-repeatable run annotations

--- a/taurus/demo/tests/test_cake.py
+++ b/taurus/demo/tests/test_cake.py
@@ -39,12 +39,12 @@ def test_cake():
         tot_count += 1
 
     recursive_foreach(cake, increment)
-    assert tot_count == 129
+    assert tot_count == 130
 
     # And make sure nothing was lost
     tot_count = 0
     recursive_foreach(loads(dumps(complete_material_history(cake))), increment)
-    assert tot_count == 129
+    assert tot_count == 130
 
     # Check that no UIDs collide
     uid_seen = dict()


### PR DESCRIPTION
Product/FE requested that parameters be added to measurement objects.

* This is still sensitive to the total-object-count validation, which serves as a regression test but may fail to be testing the right thing.
* Added the ParameterTemplate `Expected Sample Size`
* Added `Expected Sample Size` to the `Nutritional Analysis` and `Elemental Analysis` MeasurementTemplate
* Added Parameter `Expected Sample Size` to `Flour nutritional analysis`, `Salt elemental analysis`, `Sugar elemental analysis`, `Nutritional analysis` and `Elemental analysis` Measurement Runs and Measurement Specs