### PR TITLE
Corrected typo in PIF

### DIFF
--- a/taurus/demo/strehlow_and_cook.pif
+++ b/taurus/demo/strehlow_and_cook.pif
@@ -54031,7 +54031,7 @@
         "name": "Temperature derivative of band gap",
         "scalars": [
           {
-            "value": "6.00e04"
+            "value": "6.00e-04"
           }
         ],
         "units": "eV/K",


### PR DESCRIPTION
A value of 6.00e-4 was stored as 6.00e4, thus violating bounds.  Correct behavior of other records has been verified.