### PR TITLE
Remove type hints because we don't strip them during deployment

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -58,7 +58,8 @@ setup(name='taurus-citrine',
           "pint>=0.9",
           "strip-hints>=0.1.5"
       ],
-      cmdclass={
-          'install': PostInstallCommand,
-          'develop': PostDevelopCommand
-      })
+      # cmdclass={
+      #     'install': PostInstallCommand,
+      #     'develop': PostDevelopCommand
+      #}
+      )

--- a/setup.py
+++ b/setup.py
@@ -58,6 +58,7 @@ setup(name='taurus-citrine',
           "pint>=0.9",
           "strip-hints>=0.1.5"
       ],
+      # TODO: add this back when we apply them on deployments
       # cmdclass={
       #     'install': PostInstallCommand,
       #     'develop': PostDevelopCommand

--- a/taurus/demo/measurement_example.py
+++ b/taurus/demo/measurement_example.py
@@ -10,7 +10,7 @@ from taurus.enumeration import Origin
 
 # recommended values taken from
 # https://www.shimadzu.com/an/industry/petrochemicalchemical/n9j25k00000pyv3w.html
-thickness: float = 4.0  # mm
+thickness = 4.0  # mm
 length = 80.0  # mm
 width = 10.0  # mm
 span = 64.0  # mm

--- a/taurus/entity/dict_serializable.py
+++ b/taurus/entity/dict_serializable.py
@@ -1,6 +1,5 @@
 from abc import ABC
 from logging import getLogger
-from typing import Iterable  # noqa: F401
 
 import json
 import inspect
@@ -15,7 +14,7 @@ class DictSerializable(ABC):
     """A base class for objects that can be represented as a dictionary and serialized."""
 
     typ = NotImplemented
-    skip: Iterable[str] = set()
+    skip = set()
 
     @classmethod
     def from_dict(cls, d):


### PR DESCRIPTION
We were using strip-hints to provide python 3.5 support.  However,
those hints aren't being stripped in the distribution that we
publish to pypi.  Rather than try to roll forward, we're rolling
back type hints for now to maintain the ability to test against
python 3.5 in citrine-python.

These will be added back when we have a process for stripping
them for deployments.