### PR TITLE
Bugfix: json_encoder.dump was dropping material -> measurement links

### DIFF
--- a/taurus/client/tests/test_json.py
+++ b/taurus/client/tests/test_json.py
@@ -600,3 +600,7 @@ def test_deeply_nested_rehydration():
     material_history = loads(json_str)
     assert isinstance(material_history.process.ingredients[1].spec, IngredientSpec)
     assert isinstance(material_history.measurements[0], MeasurementRun)
+
+    copied = loads(dumps(material_history))
+    assert isinstance(copied.process.ingredients[1].spec, IngredientSpec)
+    assert isinstance(copied.measurements[0], MeasurementRun)

--- a/taurus/entity/object/material_run.py
+++ b/taurus/entity/object/material_run.py
@@ -126,4 +126,11 @@ class MaterialRun(BaseObject):
 
     @property
     def _forward(self) -> Iterable[str]:
+        """List of forward links that should be skipped when doing a chronological traversal.
+
+        There are no forward links present in the material run.  The only item in skip,
+        measurements, should be included when doing a "chronological" traversal.  It just
+        shouldn't be included *as a member* when serializing the material run objects.
+        :return: an empty set
+        """
         return {}

--- a/taurus/entity/object/material_run.py
+++ b/taurus/entity/object/material_run.py
@@ -1,3 +1,5 @@
+from typing import Iterable
+
 from taurus.entity.object.base_object import BaseObject
 from taurus.enumeration import SampleType
 
@@ -121,3 +123,7 @@ class MaterialRun(BaseObject):
             return self.spec.template
         else:
             return None
+
+    @property
+    def _forward(self) -> Iterable[str]:
+        return {}

--- a/taurus/entity/object/tests/test_measurement_run.py
+++ b/taurus/entity/object/tests/test_measurement_run.py
@@ -69,10 +69,6 @@ def test_material_soft_link():
     assert loads(dumps(fluorescence)) == fluorescence, \
         "Measurement should remain unchanged when serialized"
 
-    # Serializing the material breaks the material-->measurement link.
-    assert loads(dumps(dye)).measurements == [], \
-        "Measurement information should be removed when material is serialized"
-
     assert 'measurements' in repr(dye)
     assert 'material' in repr(fluorescence)
     assert 'material' in repr(absorbance)

--- a/taurus/tests/test_examples.py
+++ b/taurus/tests/test_examples.py
@@ -162,4 +162,4 @@ def test_access_data():
 
     # check that the serialization results in the correct number of objects in the preface
     # (note that neither measurements nor ingredients are serialized)
-    assert(len(json.loads(dumps(island))[0]) == 23)
+    assert(len(json.loads(dumps(island))[0]) == 26)


### PR DESCRIPTION
When we dump a MaterialRun, we want to dump any of its connected
MeasurementRuns as well (at least nominally).