### PR TITLE
Encapsulate json config in a class; support extensibility

### DIFF
--- a/docs/source/depth/index.rst
+++ b/docs/source/depth/index.rst
@@ -6,3 +6,4 @@ In depth documentation
    :maxdepth: 2
 
    unit_parsing
+   serialization

--- a/docs/source/depth/serialization.rst
+++ b/docs/source/depth/serialization.rst
@@ -1,3 +1,5 @@
+.. _Serialization In Depth:
+
 ==============================
 Serialization (with Graphs!)
 ==============================
@@ -26,7 +28,7 @@ c. Objects that are referenced by multiple objects must be deserialized to the s
 These challenges are addressed by a custom json serialization procedure and the special :class:`~taurus.entity.link_by_uid.LinkByUID` class.
 
 1. Each entity that doesn't already have at least one unique identifier is assigned a unique identifier so it can be referenced.
-2. The graph is flattened by traversing it while maintaining a seen list and replacing pointers to other entities with :class:`~taurus.entity.link_by_uid.LinkByUID` objects, producing the set of entities that are reachable.
+2. The graph is flattened by traversing it while maintaining a seen list and replacing object references to other entities with :class:`~taurus.entity.link_by_uid.LinkByUID` objects, producing the set of entities that are reachable.
 3. The objects are sorted into a special "writable" order that ensures that link targets are created when deserializing.
 4. This sorted list of entities is assigned to the "context" field in the serialization output.
 5. The original object (which may contain multiple entities) is assigned to the "object" field in the serialization output.
@@ -83,3 +85,6 @@ it knows how to build taurus entities and other :class:`~taurus.entity.dict_seri
 it creates an index with the unique identifiers of the taurus entities that it has seen so far,
 and it replaces any :class:`~taurus.entity.link_by_uid.LinkByUID` that it encounters with objects from that index.
 The only thing left to do is return the ``"object"`` item from the resulting dictionary.
+
+This strategy is implemented in the :class:`~taurus.json.taurus_json.TaurusJson` class
+and conveniently exposed in the :py:mod:`taurus.json` module, which provides the familiar `json` interface.

--- a/docs/source/depth/serialization.rst
+++ b/docs/source/depth/serialization.rst
@@ -1,0 +1,85 @@
+==============================
+Serialization (with Graphs!)
+==============================
+
+Taurus objects link together to form graphs with directional edges.
+For example, a :class:`~taurus.entity.object.material_run.MaterialRun` links back to the :class:`~taurus.entity.object.process_run.ProcessRun` that produced it.
+Some of these links are bi-directional.
+For example, a :class:`~taurus.entity.object.process_run.ProcessRun` also links forward to the :class:`~taurus.entity.object.material_run.MaterialRun` that it produces, if there is one.
+Other links are uni-directional.
+For example, a :class:`~taurus.entity.object.material_run.MaterialRun` links to its :class:`~taurus.entity.object.material_spec.MaterialSpec` but that :class:`~taurus.entity.object.material_spec.MaterialSpec` doesn't link back.
+Uni-directional links are typically used when the multiplicity of a relationship can be large.
+For example, a material may be referenced in thousands of ingredients.
+
+In taurus, bi-directional links are readable but only a single direction is writable.
+For example, a :class:`~taurus.entity.object.measurement_run.MeasurementRun` can set the :class:`~taurus.entity.object.material_run.MaterialRun` material that it was performed on,
+but a :class:`~taurus.entity.object.material_run.MaterialRun` cannot set the :class:`~taurus.entity.object.measurement_run.MeasurementRun`s it contains.
+Each time a :class:`~taurus.entity.object.measurement_run.MeasurementRun`'s ``material`` field is set,
+that :class:`~taurus.entity.object.material_run.MaterialRun` has the :class:`~taurus.entity.object.measurement_run.MeasurementRun` appended to its ``measurements`` field.
+
+This linking structure presents several challenges for serialization and deserialization:
+
+a. The graph cannot be traversed through uni-directional links in the wrong direction.
+b. Only the writeable side of bi-directional links can be persisted.
+c. Objects that are referenced by multiple objects must be deserialized to the same object.
+
+These challenges are addressed by a custom json serialization procedure and the special :class:`~taurus.entity.link_by_uid.LinkByUID` class.
+
+1. Each entity that doesn't already have at least one unique identifier is assigned a unique identifier so it can be referenced.
+2. The graph is flattened by traversing it while maintaining a seen list and replacing pointers to other entities with :class:`~taurus.entity.link_by_uid.LinkByUID` objects, producing the set of entities that are reachable.
+3. The objects are sorted into a special "writable" order that ensures that link targets are created when deserializing.
+4. This sorted list of entities is assigned to the "context" field in the serialization output.
+5. The original object (which may contain multiple entities) is assigned to the "object" field in the serialization output.
+6. The serialization output is serialized with a special :class:`~json.JSONEncoder`, :class:`~taurus.json.taurus_encoder.TaurusEncoder`, that skips the soft side of links.
+
+Here's an example of the serialized output for a :class:`~taurus.entity.object.material_spec.MaterialSpec` and :class:`~taurus.entity.object.process_spec.ProcessSpec`:
+
+::
+
+  {
+    "context": [
+      {
+        "conditions": [],
+        "file_links": [],
+        "name": "producing process",
+        "notes": null,
+        "parameters": [],
+        "tags": [],
+        "template": null,
+        "type": "process_spec",
+        "uids": {
+          "auto": "a103b759-b3e9-472e-8ec1-c69ee5d1981a"
+        }
+      },
+      {
+        "file_links": [],
+        "name": "Produced material",
+        "notes": null,
+        "process": {
+          "id": "a103b759-b3e9-472e-8ec1-c69ee5d1981a",
+          "scope": "auto",
+          "type": "link_by_uid"
+        },
+        "properties": [],
+        "tags": [],
+        "template": null,
+        "type": "material_spec",
+        "uids": {
+          "auto": "ad2c31ab-e8c0-40f1-a1b6-c5b5950026cd"
+        }
+      }
+    ],
+    "object": {
+      "id": "ad2c31ab-e8c0-40f1-a1b6-c5b5950026cd",
+      "scope": "auto",
+      "type": "link_by_uid"
+    }
+  }
+
+The deserialization is a comparatively simple two-step process.
+First, the string or file is deserialized with python's builtin deserializer and a custom object hook.
+This hook does three things:
+it knows how to build taurus entities and other :class:`~taurus.entity.dict_serializable.DictSerializable` objects,
+it creates an index with the unique identifiers of the taurus entities that it has seen so far,
+and it replaces any :class:`~taurus.entity.link_by_uid.LinkByUID` that it encounters with objects from that index.
+The only thing left to do is return the ``"object"`` item from the resulting dictionary.

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ pint==0.9
 strip-hints==0.1.7
 sphinx==2.2.0
 sphinxcontrib-apidoc==0.3.0
+deprecation==2.0.7

--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,8 @@ setup(name='taurus-citrine',
           "pytest>=4.3",
           "enum34",
           "pint>=0.9",
-          "strip-hints>=0.1.5"
+          "strip-hints>=0.1.5",
+          "deprecation>=2.0.7,<3"
       ],
       # TODO: add this back when we apply them on deployments
       # cmdclass={

--- a/taurus/client/json_encoder.py
+++ b/taurus/client/json_encoder.py
@@ -1,275 +1,53 @@
+# flake8: noqa
 """Encoding and decoding taurus objects to/from json."""
-import inspect
-import json
-
-from taurus.entity.attribute.condition import Condition
-from taurus.entity.attribute.parameter import Parameter
-from taurus.entity.attribute.property import Property
-from taurus.entity.attribute.property_and_conditions import PropertyAndConditions
-from taurus.entity.base_entity import BaseEntity
-from taurus.entity.bounds.categorical_bounds import CategoricalBounds
-from taurus.entity.bounds.composition_bounds import CompositionBounds
-from taurus.entity.bounds.integer_bounds import IntegerBounds
-from taurus.entity.bounds.real_bounds import RealBounds
-from taurus.entity.dict_serializable import DictSerializable
-from taurus.entity.file_link import FileLink
-from taurus.entity.link_by_uid import LinkByUID
-from taurus.entity.object import ProcessRun, MaterialRun, MeasurementRun
-from taurus.entity.object.ingredient_run import IngredientRun
-from taurus.entity.object.ingredient_spec import IngredientSpec
-from taurus.entity.object.material_spec import MaterialSpec
-from taurus.entity.object.measurement_spec import MeasurementSpec
-from taurus.entity.object.process_spec import ProcessSpec
-from taurus.entity.source.performed_source import PerformedSource
-from taurus.entity.template.condition_template import ConditionTemplate
-from taurus.entity.template.material_template import MaterialTemplate
-from taurus.entity.template.measurement_template import MeasurementTemplate
-from taurus.entity.template.parameter_template import ParameterTemplate
-from taurus.entity.template.process_template import ProcessTemplate
-from taurus.entity.template.property_template import PropertyTemplate
-from taurus.entity.value.discrete_categorical import DiscreteCategorical
-from taurus.entity.value.empirical_formula import EmpiricalFormula
-from taurus.entity.value.nominal_categorical import NominalCategorical
-from taurus.entity.value.nominal_composition import NominalComposition
-from taurus.entity.value.nominal_integer import NominalInteger
-from taurus.entity.value.nominal_real import NominalReal
-from taurus.entity.value.normal_real import NormalReal
-from taurus.entity.value.uniform_integer import UniformInteger
-from taurus.entity.value.uniform_real import UniformReal
-from taurus.enumeration.base_enumeration import BaseEnumeration
-from taurus.json import TaurusEncoder
-from taurus.util import flatten, substitute_links, set_uuids
+import deprecation
+import taurus
+from taurus.json import TaurusEncoder, TaurusJson
 
 
+@deprecation.deprecated(deprecated_in="0.6.0", removed_in="0.7.0",
+                        details="Use taurus.json.dumps instead")
 def dumps(obj, **kwargs):
-    """
-    Serialize a taurus object, or container of them, into a json-formatting string.
-
-    Parameters
-    ----------
-    obj: DictSerializable or List[DictSerializable]
-        The object(s) to serialize to a string.
-    **kwargs: keyword args, optional
-        Optional keyword arguments to pass to `json.dumps()`.
-
-    Returns
-    -------
-    str
-        A string version of the serialized objects.
-
-    """
-    # create a top level list of [flattened_objects, link-i-fied return value]
-    res = [obj]
-    additional = flatten(res)
-    res = substitute_links(res)
-    res.insert(0, additional)
-    return json.dumps(res, cls=TaurusEncoder, sort_keys=True, **kwargs)
+    return taurus.json.dumps(obj, **kwargs)
 
 
+@deprecation.deprecated(deprecated_in="0.6.0", removed_in="0.7.0",
+                        details="Use taurus.json.loads instead")
 def loads(json_str, **kwargs):
-    """
-    Deserialize a json-formatted string into a taurus object.
-
-    Parameters
-    ----------
-    json_str: str
-        A string representing the serialized objects, such as what is produced by :func:`dumps`.
-    **kwargs: keyword args, optional
-        Optional keyword arguments to pass to `json.loads()`.
-
-    Returns
-    -------
-    DictSerializable or List[DictSerializable]
-        Deserialized versions of the objects represented by `json_str`, with links turned
-        back into pointers.
-
-    """
-    # Create an index to hold the objects by their uid reference
-    # so we can replace links with pointers
-    index = {}
-    raw = json.loads(json_str, object_hook=lambda x: _loado(x, index, True), **kwargs)
-    # the return value is in the 2nd position.
-    return raw[1]
+    return taurus.json.loads(json_str, **kwargs)
 
 
+@deprecation.deprecated(deprecated_in="0.6.0", removed_in="0.7.0",
+                        details="Use taurus.json.load instead")
 def load(fp, **kwargs):
-    """
-    Load serialized string representation of an object from a file.
-
-    Parameters
-    ----------
-    fp: file
-        File to read.
-    **kwargs: keyword args, optional
-        Optional keyword arguments to pass to `json.loads()`.
-
-    Returns
-    -------
-    DictSerializable or List[DictSerializable]
-        Deserialized object(s).
-
-    """
-    return loads(fp.read(), **kwargs)
+    return taurus.json.load(fp, **kwargs)
 
 
+@deprecation.deprecated(deprecated_in="0.6.0", removed_in="0.7.0",
+                        details="Use taurus.json.dump instead")
 def dump(obj, fp, **kwargs):
-    """
-    Dump an object to a file, as a serialized string.
-
-    Parameters
-    ----------
-    obj: DictSerializable or List[DictSerializable]
-        Object(s) to dump
-    fp: file
-        File to write to.
-    **kwargs: keyword args, optional
-        Optional keyword arguments to pass to `json.dumps()`.
-
-    Returns
-    -------
-    None
-
-    """
-    fp.write(dumps(obj, **kwargs))
-    return
+    return taurus.json.dump(obj, fp, **kwargs)
 
 
+@deprecation.deprecated(deprecated_in="0.6.0", removed_in="0.7.0",
+                        details="Use taurus.json.TaurusJson().raw_dumps instead")
 def raw_dumps(obj, **kwargs):
-    """
-    Serialize the object as-is, which could be as a nested object.
-
-    Parameters
-    ----------
-    obj:
-        Object to dump
-    **kwargs: keyword args, optional
-        Optional keyword arguments to pass to `json.dumps()`.
-
-    Returns
-    -------
-    str
-        A serialized string of `obj`, which could be nested
-
-    """
-    return json.dumps(obj, cls=TaurusEncoder, sort_keys=True, **kwargs)
+    return TaurusJson().raw_dumps(obj, **kwargs)
 
 
+@deprecation.deprecated(deprecated_in="0.6.0", removed_in="0.7.0",
+                        details="Use taurus.json.TaurusJson().thin_dumps instead")
 def thin_dumps(obj, **kwargs):
-    """
-    Serialize a "thin" version of an object in which pointers are replaced by links.
-
-    Parameters
-    ----------
-    obj:
-        Object to dump
-    **kwargs: keyword args, optional
-        Optional keyword arguments to pass to `json.dumps()`.
-
-    Returns
-    -------
-    str
-        A serialized string of `obj`, with link_by_uid in place of pointers to other objects.
-
-    """
-    set_uuids(obj)
-    res = substitute_links(obj)
-    return json.dumps(res, cls=TaurusEncoder, sort_keys=True, **kwargs)
+    return TaurusJson().thin_dumps(obj, **kwargs)
 
 
+@deprecation.deprecated(deprecated_in="0.6.0", removed_in="0.7.0",
+                        details="Use taurus.json.TaurusJson().raw_loads instead")
 def raw_loads(json_str, **kwargs):
-    """
-    Deserialize a json-formatted string with no preamble into a taurus object as-is.
-
-    Parameters
-    ----------
-    json_str: str
-        A string representing the serialized objects, such as what is produced by :func:`dumps`.
-    **kwargs: keyword args, optional
-        Optional keyword arguments to pass to `json.loads()`.
-
-    Returns
-    -------
-    DictSerializable or List[DictSerializable]
-        Deserialized versions of the objects represented by `json_str`
-
-    """
-    # Create an index to hold the objects by their uid reference
-    # so we can replace links with pointers
-    index = {}
-    return json.loads(json_str, object_hook=lambda x: _loado(x, index), **kwargs)
+    return TaurusJson().raw_loads(json_str, **kwargs)
 
 
+@deprecation.deprecated(deprecated_in="0.6.0", removed_in="0.7.0",
+                        details="Use taurus.json.TaurusJson().copy instead")
 def copy(obj):
-    """
-    Copy an object by dumping and then loading it.
-
-    Parameters
-    ----------
-    obj: DictSerializable
-        Object to copy
-
-    Returns
-    -------
-    DictSerializable
-        A copy of `obj`.
-
-    """
-    return loads(dumps(obj))
-
-
-def register_classes(classes):
-    if not isinstance(classes, dict):
-        raise ValueError("Must be given a dict from str -> class")
-    non_string_keys = [x for x in classes.keys() if not isinstance(x, str)]
-    if len(non_string_keys) > 0:
-        raise ValueError("The keys must be strings, but got {} as keys".format(non_string_keys))
-    non_class_values = [x for x in classes.values() if not inspect.isclass(x)]
-    if len(non_class_values) > 0:
-        raise ValueError(
-            "The values must be classes, but got {} as values".format(non_class_values))
-
-    _clazz_index.update(classes)
-    return
-
-
-# build index from the class's typ member to the class itself
-_clazzes = [
-    MaterialTemplate, MeasurementTemplate, ProcessTemplate,
-    MaterialSpec, MeasurementSpec, ProcessSpec, IngredientSpec,
-    ProcessRun, MaterialRun, MeasurementRun, IngredientRun,
-    Property, Condition, Parameter, PropertyAndConditions,
-    PropertyTemplate, ConditionTemplate, ParameterTemplate,
-    RealBounds, IntegerBounds, CategoricalBounds, CompositionBounds,
-    NominalComposition, EmpiricalFormula,
-    NominalReal, UniformReal, NormalReal, DiscreteCategorical, NominalCategorical,
-    UniformInteger, NominalInteger,
-    FileLink, PerformedSource
-]
-_clazz_index = {}
-for clazz in _clazzes:
-    _clazz_index[clazz.typ] = clazz
-
-
-def _loado(d, index, substitute=False):
-    if "type" not in d:
-        return d
-    typ = d.pop("type")
-
-    if typ in _clazz_index:
-        clz = _clazz_index[typ]
-        obj = clz.from_dict(d)
-    elif typ == LinkByUID.typ:
-        obj = LinkByUID.from_dict(d)
-        if substitute and (obj.scope.lower(), obj.id) in index:
-            return index[(obj.scope.lower(), obj.id)]
-        return obj
-    else:
-        raise TypeError("Unexpected base object type: {}".format(typ))
-
-    if isinstance(obj, BaseEntity):
-        for (scope, id) in obj.uids.items():
-            index[(scope.lower(), id)] = obj
-    return obj
-
-
-
+    return TaurusJson().copy(obj)

--- a/taurus/demo/cake.py
+++ b/taurus/demo/cake.py
@@ -39,7 +39,7 @@ from taurus.entity.util import complete_material_history, make_instance
 from taurus.entity.file_link import FileLink
 from taurus.entity.source.performed_source import PerformedSource
 
-from taurus.client.json_encoder import thin_dumps
+from taurus.json import TaurusJson
 from taurus.util.impl import recursive_foreach
 
 
@@ -925,6 +925,7 @@ def make_cake(seed=None, tmpl=None, cake_spec=None):
 
 
 if __name__ == "__main__":
+    encoder = TaurusJson()
     cake = make_cake(seed=42)
 
     with open("example_taurus_material_history.json", "w") as f:
@@ -932,34 +933,35 @@ if __name__ == "__main__":
         f.write(json.dumps(context_list, indent=2))
 
     with open("example_taurus_material_template.json", "w") as f:
-        f.write(thin_dumps(cake.template, indent=2))
+        f.write(encoder.thin_dumps(cake.template, indent=2))
 
     with open("example_taurus_process_template.json", "w") as f:
-        f.write(thin_dumps(cake.process.ingredients[0].material.process.template, indent=2))
+        f.write(
+            encoder.thin_dumps(cake.process.ingredients[0].material.process.template, indent=2))
 
     with open("example_taurus_measurement_template.json", "w") as f:
-        f.write(thin_dumps(cake.measurements[0].template, indent=2))
+        f.write(encoder.thin_dumps(cake.measurements[0].template, indent=2))
 
     with open("example_taurus_material_spec.json", "w") as f:
-        f.write(thin_dumps(cake.spec, indent=2))
+        f.write(encoder.thin_dumps(cake.spec, indent=2))
 
     with open("example_taurus_process_spec.json", "w") as f:
-        f.write(thin_dumps(cake.process.spec, indent=2))
+        f.write(encoder.thin_dumps(cake.process.spec, indent=2))
 
     with open("example_taurus_ingredient_spec.json", "w") as f:
-        f.write(thin_dumps(cake.process.spec.ingredients[0], indent=2))
+        f.write(encoder.thin_dumps(cake.process.spec.ingredients[0], indent=2))
 
     with open("example_taurus_measurement_spec.json", "w") as f:
-        f.write(thin_dumps(cake.measurements[0].spec, indent=2))
+        f.write(encoder.thin_dumps(cake.measurements[0].spec, indent=2))
 
     with open("example_taurus_material_run.json", "w") as f:
-        f.write(thin_dumps(cake, indent=2))
+        f.write(encoder.thin_dumps(cake, indent=2))
 
     with open("example_taurus_process_run.json", "w") as f:
-        f.write(thin_dumps(cake.process, indent=2))
+        f.write(encoder.thin_dumps(cake.process, indent=2))
 
     with open("example_taurus_ingredient_run.json", "w") as f:
-        f.write(thin_dumps(cake.process.ingredients[0], indent=2))
+        f.write(encoder.thin_dumps(cake.process.ingredients[0], indent=2))
 
     with open("example_taurus_measurement_run.json", "w") as f:
-        f.write(thin_dumps(cake.measurements[0], indent=2))
+        f.write(encoder.thin_dumps(cake.measurements[0], indent=2))

--- a/taurus/demo/strehlow_and_cook.py
+++ b/taurus/demo/strehlow_and_cook.py
@@ -464,7 +464,7 @@ if __name__ == "__main__":
         json.dump(reduced_list, f, indent=2)
 
     print("\n\nJSON -- Training table")
-    import taurus.client.json_encoder as je
+    import taurus.json as je
     print(json.dumps(json.loads(je.dumps(full_table))[1], indent=2))
 
     print("\n\nCSV -- Display table")

--- a/taurus/demo/tests/test_cake.py
+++ b/taurus/demo/tests/test_cake.py
@@ -8,7 +8,7 @@ from taurus.entity.object.measurement_run import MeasurementRun
 from taurus.entity.object.ingredient_spec import IngredientSpec
 from taurus.entity.object.ingredient_run import IngredientRun
 
-from taurus.client.json_encoder import dumps, loads
+from taurus.json import dumps, loads
 from taurus.demo.cake import make_cake, import_toothpick_picture
 from taurus.util import recursive_foreach
 from taurus.entity.util import complete_material_history

--- a/taurus/demo/tests/test_measurement_run_example.py
+++ b/taurus/demo/tests/test_measurement_run_example.py
@@ -1,5 +1,5 @@
 """Test measurement demo."""
-from taurus.client.json_encoder import dumps, load
+from taurus.json import dumps, load
 from taurus.demo.measurement_example import make_demo_measurements
 
 

--- a/taurus/demo/tests/test_sac.py
+++ b/taurus/demo/tests/test_sac.py
@@ -1,7 +1,7 @@
 """Test Strehlow & Cook demo."""
 from taurus.demo.strehlow_and_cook import make_strehlow_table, make_strehlow_objects, \
     minimal_subset, import_table
-import taurus.client.json_encoder as je
+import taurus.json as je
 
 
 def test_sac():

--- a/taurus/entity/bounds/tests/test_categorical_bounds.py
+++ b/taurus/entity/bounds/tests/test_categorical_bounds.py
@@ -1,7 +1,7 @@
 """Test of CategoricalBounds."""
 import pytest
 
-from taurus.client.json_encoder import dumps, loads
+from taurus.json import dumps, loads
 from taurus.entity.bounds.categorical_bounds import CategoricalBounds
 from taurus.entity.bounds.real_bounds import RealBounds
 from taurus.entity.util import array_like

--- a/taurus/entity/bounds/tests/test_composition_bounds.py
+++ b/taurus/entity/bounds/tests/test_composition_bounds.py
@@ -1,7 +1,7 @@
 """Test CompositionBounds."""
 import pytest
 
-from taurus.client.json_encoder import dumps, loads
+from taurus.json import dumps, loads
 from taurus.entity.bounds.composition_bounds import CompositionBounds
 from taurus.entity.bounds.real_bounds import RealBounds
 from taurus.entity.util import array_like

--- a/taurus/entity/dict_serializable.py
+++ b/taurus/entity/dict_serializable.py
@@ -6,7 +6,6 @@ import inspect
 
 # There are some weird (probably resolvable) errors during object cloning if this is an
 # instance variable of DictSerializable.
-
 logger = getLogger(__name__)
 
 
@@ -72,8 +71,9 @@ class DictSerializable(ABC):
             A string representation of the object as a dictionary.
 
         """
-        from taurus.client.json_encoder import raw_dumps
-        return json.loads(raw_dumps(self))
+        from taurus.json import TaurusJson
+        encoder = TaurusJson()
+        return json.loads(encoder.raw_dumps(self))
 
     @staticmethod
     def build(d):
@@ -94,9 +94,9 @@ class DictSerializable(ABC):
             The deserialized object.
 
         """
-        from taurus.client.json_encoder import raw_dumps, raw_loads
-
-        return raw_loads(raw_dumps(d))
+        from taurus.json import TaurusJson
+        encoder = TaurusJson()
+        return encoder.raw_loads(encoder.raw_dumps(d))
 
     def __repr__(self):
         object_dict = self.as_dict()

--- a/taurus/entity/object/tests/test_material_run.py
+++ b/taurus/entity/object/tests/test_material_run.py
@@ -4,7 +4,7 @@ import json
 from uuid import uuid4
 from copy import deepcopy
 
-from taurus.client.json_encoder import loads, dumps
+from taurus.json import loads, dumps
 from taurus.entity.attribute.property_and_conditions import PropertyAndConditions
 from taurus.entity.object import MaterialRun, ProcessRun, MaterialSpec
 from taurus.entity.template.material_template import MaterialTemplate

--- a/taurus/entity/object/tests/test_material_run.py
+++ b/taurus/entity/object/tests/test_material_run.py
@@ -34,7 +34,7 @@ def test_material_run():
 
     # Make sure that when property is serialized, origin (an enumeration) is serialized as a string
     copy_prop = json.loads(dumps(mat_spec))
-    copy_origin = copy_prop[0][0]["properties"][0]['property']['origin']
+    copy_origin = copy_prop["context"][0]["properties"][0]['property']['origin']
     assert isinstance(copy_origin, str)
 
     # Create a MaterialRun, and make sure an inappropriate value for sample_type throws ValueError

--- a/taurus/entity/object/tests/test_measurement_run.py
+++ b/taurus/entity/object/tests/test_measurement_run.py
@@ -2,7 +2,7 @@
 import pytest
 from uuid import uuid4
 
-from taurus.client.json_encoder import dumps, loads
+from taurus.json import dumps, loads
 from taurus.entity.object import MeasurementRun, MaterialRun
 from taurus.entity.object.measurement_spec import MeasurementSpec
 from taurus.entity.attribute.condition import Condition

--- a/taurus/entity/object/tests/test_process_run.py
+++ b/taurus/entity/object/tests/test_process_run.py
@@ -2,7 +2,7 @@
 import pytest
 from uuid import uuid4
 
-from taurus.client.json_encoder import dumps, loads
+from taurus.json import dumps, loads
 from taurus.entity.object.process_run import ProcessRun
 from taurus.entity.object.process_spec import ProcessSpec
 from taurus.entity.attribute.condition import Condition

--- a/taurus/entity/object/tests/test_process_spec.py
+++ b/taurus/entity/object/tests/test_process_spec.py
@@ -1,7 +1,7 @@
 """Tests of the process spec object."""
 import pytest
 
-from taurus.client.json_encoder import dumps, loads
+from taurus.json import dumps, loads
 from taurus.entity.attribute.property_and_conditions import PropertyAndConditions
 from taurus.entity.object.process_spec import ProcessSpec
 from taurus.entity.object.material_spec import MaterialSpec

--- a/taurus/entity/template/tests/test_base_attribute_template.py
+++ b/taurus/entity/template/tests/test_base_attribute_template.py
@@ -6,7 +6,7 @@ from taurus.entity.bounds.real_bounds import RealBounds
 from taurus.entity.value.uniform_real import UniformReal
 from taurus.entity.template.attribute_template import AttributeTemplate
 from taurus.entity.template.property_template import PropertyTemplate
-from taurus.client.json_encoder import dumps, loads
+from taurus.json import dumps, loads
 
 
 class SampleAttributeTemplate(AttributeTemplate):

--- a/taurus/entity/tests/test_case_insensitive_dict.py
+++ b/taurus/entity/tests/test_case_insensitive_dict.py
@@ -3,7 +3,7 @@ import pytest
 
 from taurus.entity.case_insensitive_dict import CaseInsensitiveDict
 from taurus.entity.object.process_run import ProcessRun
-from taurus.client.json_encoder import loads, dumps
+from taurus.json import loads, dumps
 
 
 def test_case_sensitivity():

--- a/taurus/entity/tests/test_link_by_uid.py
+++ b/taurus/entity/tests/test_link_by_uid.py
@@ -1,5 +1,5 @@
 """General tests of LinkByUID dynamics."""
-from taurus.client.json_encoder import dumps, loads
+from taurus.json import dumps, loads
 from taurus.entity.object.material_run import MaterialRun
 from taurus.entity.object.process_run import ProcessRun
 from taurus.entity.object.ingredient_run import IngredientRun

--- a/taurus/entity/util.py
+++ b/taurus/entity/util.py
@@ -106,14 +106,14 @@ def complete_material_history(mat):
     """
     from taurus.entity.base_entity import BaseEntity
     import json
-    from taurus.client.json_encoder import dumps, loads
+    from taurus.json import dumps, loads
     from taurus.util.impl import substitute_links
 
     result = []
 
     def body(obj: BaseEntity):
         copy = substitute_links(loads(dumps(obj)))
-        result.append(json.loads(dumps(copy))[0][0])
+        result.append(json.loads(dumps(copy))["context"][0])
 
     recursive_foreach(mat, body, apply_first=False)
 

--- a/taurus/entity/value/tests/test_empirical_formula.py
+++ b/taurus/entity/value/tests/test_empirical_formula.py
@@ -1,7 +1,7 @@
 """Test parsing and serde of empirical chemical formulae."""
 import pytest
 
-from taurus.client.json_encoder import dumps, loads
+from taurus.json import dumps, loads
 from taurus.entity.value.empirical_formula import EmpiricalFormula
 
 

--- a/taurus/enumeration/tests/test_enumeration.py
+++ b/taurus/enumeration/tests/test_enumeration.py
@@ -4,7 +4,7 @@ import pytest
 from taurus.entity.attribute.property import Property
 from taurus.enumeration import Origin
 from taurus.enumeration.base_enumeration import BaseEnumeration
-from taurus.client.json_encoder import loads, dumps
+from taurus.json import loads, dumps
 
 
 def test_values():

--- a/taurus/ingest/tests/test_material_run_example.py
+++ b/taurus/ingest/tests/test_material_run_example.py
@@ -1,5 +1,5 @@
 """Test the ingestion of a material run."""
-from taurus.client.json_encoder import dump, load
+from taurus.json import dump, load
 from taurus.ingest.material_run_example import ingest_material_run
 import tempfile
 

--- a/taurus/ingest/tests/test_table_example.py
+++ b/taurus/ingest/tests/test_table_example.py
@@ -1,7 +1,7 @@
 """Test an example table."""
 import pandas as pd
 
-from taurus.client.json_encoder import load, dump
+from taurus.json import load, dump
 from taurus.entity.object import MaterialRun
 from taurus.ingest.table_example import ingest_table
 

--- a/taurus/json/__init__.py
+++ b/taurus/json/__init__.py
@@ -1,4 +1,4 @@
-from .taurus_encoder import TaurusEncoder
+from .taurus_encoder import TaurusEncoder  # noqa: F401
 from .taurus_json import TaurusJson
 
 __default = TaurusJson()

--- a/taurus/json/__init__.py
+++ b/taurus/json/__init__.py
@@ -37,7 +37,7 @@ def loads(json_str, **kwargs):
     -------
     DictSerializable or List[DictSerializable]
         Deserialized versions of the objects represented by `json_str`, with links turned
-        back into object references (python's pointers).
+        back into python object references.
 
     """
     return __default.loads(json_str, **kwargs)

--- a/taurus/json/__init__.py
+++ b/taurus/json/__init__.py
@@ -1,3 +1,21 @@
+"""Taurus JSON support, which provides a drop-in replacement for json.
+
+This module provides the four main python json methods:
+
+* :func:`dump` for serializing python and taurus objects to a JSON file
+* :func:`load` for deserializing python and taurus objects from a JSON file
+* :func:`dumps` for serializing python and taurus objects into a String
+* :func:`loads` for deserializing python and taurus objects from a String
+
+These methods should provide drop-in support for serialization and deserialization of
+taurus-containing data structures by replacing imports of ``json`` with those of ``taurus.json``.
+
+It also provides convenience imports of :class:`~taurus_encoder.TaurusEncoder`
+and :class:`~taurus_json.TaurusJson`.
+These classes can be used by developers to integrate taurus with other tools by extending the
+JSON support provided here to those tools.
+"""
+
 from .taurus_encoder import TaurusEncoder  # noqa: F401
 from .taurus_json import TaurusJson
 
@@ -19,7 +37,7 @@ def loads(json_str, **kwargs):
     -------
     DictSerializable or List[DictSerializable]
         Deserialized versions of the objects represented by `json_str`, with links turned
-        back into pointers.
+        back into object references (python's pointers).
 
     """
     return __default.loads(json_str, **kwargs)

--- a/taurus/json/__init__.py
+++ b/taurus/json/__init__.py
@@ -1,0 +1,86 @@
+from .taurus_encoder import TaurusEncoder
+from .taurus_json import TaurusJson
+
+__default = TaurusJson()
+
+
+def loads(json_str, **kwargs):
+    """
+    Deserialize a json-formatted string into a taurus object.
+
+    Parameters
+    ----------
+    json_str: str
+        A string representing the serialized objects, such as what is produced by :func:`dumps`.
+    **kwargs: keyword args, optional
+        Optional keyword arguments to pass to `json.loads()`.
+
+    Returns
+    -------
+    DictSerializable or List[DictSerializable]
+        Deserialized versions of the objects represented by `json_str`, with links turned
+        back into pointers.
+
+    """
+    return __default.loads(json_str, **kwargs)
+
+
+def dumps(obj, **kwargs):
+    """
+    Serialize a taurus object, or container of them, into a json-formatting string.
+
+    Parameters
+    ----------
+    obj: DictSerializable or List[DictSerializable]
+        The object(s) to serialize to a string.
+    **kwargs: keyword args, optional
+        Optional keyword arguments to pass to `json.dumps()`.
+
+    Returns
+    -------
+    str
+        A string version of the serialized objects.
+
+    """
+    return __default.dumps(obj, **kwargs)
+
+
+def load(fp, **kwargs):
+    """
+    Load serialized string representation of an object from a file.
+
+    Parameters
+    ----------
+    fp: file
+        File to read.
+    **kwargs: keyword args, optional
+        Optional keyword arguments to pass to `json.loads()`.
+
+    Returns
+    -------
+    DictSerializable or List[DictSerializable]
+        Deserialized object(s).
+
+    """
+    return __default.load(fp, **kwargs)
+
+
+def dump(obj, fp, **kwargs):
+    """
+    Dump an object to a file, as a serialized string.
+
+    Parameters
+    ----------
+    obj: DictSerializable or List[DictSerializable]
+        Object(s) to dump
+    fp: file
+        File to write to.
+    **kwargs: keyword args, optional
+        Optional keyword arguments to pass to `json.dumps()`.
+
+    Returns
+    -------
+    None
+
+    """
+    return __default.dump(obj, fp, **kwargs)

--- a/taurus/json/taurus_encoder.py
+++ b/taurus/json/taurus_encoder.py
@@ -1,0 +1,17 @@
+from json import JSONEncoder
+
+from taurus.entity.dict_serializable import DictSerializable
+from taurus.enumeration.base_enumeration import BaseEnumeration
+
+
+class TaurusEncoder(JSONEncoder):
+    """Rules for encoding taurus objects as json strings."""
+
+    def default(self, o):
+        """Default encoder implementation."""
+        if isinstance(o, DictSerializable):
+            return o.as_dict()
+        elif isinstance(o, BaseEnumeration):
+            return o.value
+        else:
+            return JSONEncoder.default(self, o)

--- a/taurus/json/taurus_json.py
+++ b/taurus/json/taurus_json.py
@@ -1,0 +1,185 @@
+import inspect
+
+from taurus.entity.attribute.condition import Condition
+from taurus.entity.attribute.parameter import Parameter
+from taurus.entity.attribute.property import Property
+from taurus.entity.attribute.property_and_conditions import PropertyAndConditions
+from taurus.entity.base_entity import BaseEntity
+from taurus.entity.bounds.categorical_bounds import CategoricalBounds
+from taurus.entity.bounds.composition_bounds import CompositionBounds
+from taurus.entity.bounds.integer_bounds import IntegerBounds
+from taurus.entity.bounds.real_bounds import RealBounds
+from taurus.entity.dict_serializable import DictSerializable
+from taurus.entity.file_link import FileLink
+from taurus.entity.link_by_uid import LinkByUID
+from taurus.entity.object import ProcessRun, MaterialRun, MeasurementRun
+from taurus.entity.object.ingredient_run import IngredientRun
+from taurus.entity.object.ingredient_spec import IngredientSpec
+from taurus.entity.object.material_spec import MaterialSpec
+from taurus.entity.object.measurement_spec import MeasurementSpec
+from taurus.entity.object.process_spec import ProcessSpec
+from taurus.entity.source.performed_source import PerformedSource
+from taurus.entity.template.condition_template import ConditionTemplate
+from taurus.entity.template.material_template import MaterialTemplate
+from taurus.entity.template.measurement_template import MeasurementTemplate
+from taurus.entity.template.parameter_template import ParameterTemplate
+from taurus.entity.template.process_template import ProcessTemplate
+from taurus.entity.template.property_template import PropertyTemplate
+from taurus.entity.value.discrete_categorical import DiscreteCategorical
+from taurus.entity.value.empirical_formula import EmpiricalFormula
+from taurus.entity.value.nominal_categorical import NominalCategorical
+from taurus.entity.value.nominal_composition import NominalComposition
+from taurus.entity.value.nominal_integer import NominalInteger
+from taurus.entity.value.nominal_real import NominalReal
+from taurus.entity.value.normal_real import NormalReal
+from taurus.entity.value.uniform_integer import UniformInteger
+from taurus.entity.value.uniform_real import UniformReal
+from taurus.json import TaurusEncoder
+from taurus.util import flatten, substitute_links
+import json
+
+
+class TaurusJson(object):
+    _clazzes = [
+        MaterialTemplate, MeasurementTemplate, ProcessTemplate,
+        MaterialSpec, MeasurementSpec, ProcessSpec, IngredientSpec,
+        ProcessRun, MaterialRun, MeasurementRun, IngredientRun,
+        Property, Condition, Parameter, PropertyAndConditions,
+        PropertyTemplate, ConditionTemplate, ParameterTemplate,
+        RealBounds, IntegerBounds, CategoricalBounds, CompositionBounds,
+        NominalComposition, EmpiricalFormula,
+        NominalReal, UniformReal, NormalReal, DiscreteCategorical, NominalCategorical,
+        UniformInteger, NominalInteger,
+        FileLink, PerformedSource
+    ]
+
+    def __init__(self):
+        self._clazz_index = {}
+        # build index from the class's typ member to the class itself
+        for clazz in self._clazzes:
+            self._clazz_index[clazz.typ] = clazz
+        pass
+
+    def dumps(self, obj, **kwargs):
+        """
+        Serialize a taurus object, or container of them, into a json-formatting string.
+
+        Parameters
+        ----------
+        obj: DictSerializable or List[DictSerializable]
+            The object(s) to serialize to a string.
+        **kwargs: keyword args, optional
+            Optional keyword arguments to pass to `json.dumps()`.
+
+        Returns
+        -------
+        str
+            A string version of the serialized objects.
+
+        """
+        # create a top level list of [flattened_objects, link-i-fied return value]
+        res = [obj]
+        additional = flatten(res)
+        res = substitute_links(res)
+        res.insert(0, additional)
+        return json.dumps(res, cls=TaurusEncoder, sort_keys=True, **kwargs)
+
+    def loads(self, json_str, **kwargs):
+        """
+        Deserialize a json-formatted string into a taurus object.
+
+        Parameters
+        ----------
+        json_str: str
+            A string representing the serialized objects, such as what is produced by :func:`dumps`.
+        **kwargs: keyword args, optional
+            Optional keyword arguments to pass to `json.loads()`.
+
+        Returns
+        -------
+        DictSerializable or List[DictSerializable]
+            Deserialized versions of the objects represented by `json_str`, with links turned
+            back into pointers.
+
+        """
+        # Create an index to hold the objects by their uid reference
+        # so we can replace links with pointers
+        index = {}
+        raw = json.loads(
+            json_str, object_hook=lambda x: self._load_and_index(x, index, True), **kwargs)
+        # the return value is in the 2nd position.
+        return raw[1]
+
+    def load(self, fp, **kwargs):
+        """
+        Load serialized string representation of an object from a file.
+
+        Parameters
+        ----------
+        fp: file
+            File to read.
+        **kwargs: keyword args, optional
+            Optional keyword arguments to pass to `json.loads()`.
+
+        Returns
+        -------
+        DictSerializable or List[DictSerializable]
+            Deserialized object(s).
+
+        """
+        return self.loads(fp.read(), **kwargs)
+
+    def dump(self, obj, fp, **kwargs):
+        """
+        Dump an object to a file, as a serialized string.
+
+        Parameters
+        ----------
+        obj: DictSerializable or List[DictSerializable]
+            Object(s) to dump
+        fp: file
+            File to write to.
+        **kwargs: keyword args, optional
+            Optional keyword arguments to pass to `json.dumps()`.
+
+        Returns
+        -------
+        None
+
+        """
+        fp.write(self.dumps(obj, **kwargs))
+        return
+
+    def register_classes(self, classes):
+        if not isinstance(classes, dict):
+            raise ValueError("Must be given a dict from str -> class")
+        non_string_keys = [x for x in classes.keys() if not isinstance(x, str)]
+        if len(non_string_keys) > 0:
+            raise ValueError("The keys must be strings, but got {} as keys".format(non_string_keys))
+        non_class_values = [x for x in classes.values() if not inspect.isclass(x)]
+        if len(non_class_values) > 0:
+            raise ValueError(
+                "The values must be classes, but got {} as values".format(non_class_values))
+
+        self._clazz_index.update(classes)
+
+    def _load_and_index(self, d, index, substitute=False):
+        if "type" not in d:
+            return d
+        typ = d.pop("type")
+
+        if typ in self._clazz_index:
+            clz = self._clazz_index[typ]
+            obj = clz.from_dict(d)
+        elif typ == LinkByUID.typ:
+            obj = LinkByUID.from_dict(d)
+            if substitute and (obj.scope.lower(), obj.id) in index:
+                return index[(obj.scope.lower(), obj.id)]
+            return obj
+        else:
+            raise TypeError("Unexpected base object type: {}".format(typ))
+
+        if isinstance(obj, BaseEntity):
+            for (scope, uid) in obj.uids.items():
+                index[(scope.lower(), uid)] = obj
+        return obj

--- a/taurus/json/taurus_json.py
+++ b/taurus/json/taurus_json.py
@@ -42,38 +42,8 @@ class TaurusJson(object):
     """
     Class that provides json load/dump functionality that is compatible with taurus objects.
 
-    Taurus objects are connected to one another forming a graph.  This presents two challenges:
-      a) Cycles need to be broken, forming an directed acyclic graph
-      b) Duplicate paths to the same object need to be written to a single object and then
-         deserialized into the same object
-
-    The (a) problem is addressed by the structure of bidirectional taurus links: only one
-    direction of the link is writable.  For example, a link can be created between a
-    material run and a measurement run by setting the `material` field in the measurement run,
-    but not the other way around; the measurements field in material run is read-only.  This
-    is reflected in the json strategy through the `skip` member of DictSerializable, which
-    makes sure that the read-only side of bidirectional links are not written.
-
-    The second part of the solution to (a) is a seen set in the `recursive_flatmap` method
-    in util that is used by `flatten`.
-
-    The (b) problem is resolved by those same `recursive_flatmap` and `flatten` methods.  The
-    `flatten` method does a depth-first traversal of the graph, recording the first time
-    each object is traversed.  This produces a list of all of the objects that are contained
-    in the "historical" subgraph:
-      * material -> {process, measurements}
-      * process -> {ingredients}
-      * ingredient -> {process, input material}
-      * measurement -> {material}
-    This prevents traversing from materials forward to the ingredients that use them, since
-    that link doesn't exist.
-
-    The serialization format is a (context, object) tuple.  The context is the list of
-    flattened objects, while object that was being serialized but with all of the pointers
-    to other taurus entities replaced by LinkByUID objects.  The deserialization is performed
-    with a custom object hook that builds a local index of all of the objects in the context.
-    By the time it gets around to deserializing the object, it knows how to replace all of the
-    LinkByUIDs with taurus entities that had been flattened out.
+    The serialization and deserialization strategy implemented by this class is described in
+    :ref:`Serialization In Depth`
     """
 
     _clazzes = [

--- a/taurus/json/tests/test_json.py
+++ b/taurus/json/tests/test_json.py
@@ -4,7 +4,7 @@ from copy import deepcopy
 
 import pytest
 
-from taurus.client.json_encoder import dumps, loads, copy, thin_dumps, _loado
+from taurus.json import dumps, loads, TaurusJson
 from taurus.entity.attribute.property import Property
 from taurus.entity.bounds.real_bounds import RealBounds
 from taurus.entity.dict_serializable import DictSerializable
@@ -38,14 +38,14 @@ def test_serialize():
     # serialize the root of the tree
     native_object = json.loads(dumps(measurement))
     # ingredients don't get serialized on the process
-    assert(len(native_object[0]) == 5)
-    assert(native_object[1]["type"] == LinkByUID.typ)
+    assert(len(native_object["context"]) == 5)
+    assert(native_object["object"]["type"] == LinkByUID.typ)
 
     # serialize all of the nodes
     native_batch = json.loads(dumps([material, process, measurement, ingredient]))
-    assert(len(native_batch[0]) == 5)
-    assert(len(native_batch[1]) == 4)
-    assert(all(x["type"] == LinkByUID.typ for x in native_batch[1]))
+    assert(len(native_batch["context"]) == 5)
+    assert(len(native_batch["object"]) == 4)
+    assert(all(x["type"] == LinkByUID.typ for x in native_batch["object"]))
 
 
 def test_deserialize():
@@ -54,7 +54,7 @@ def test_deserialize():
     parameter = Parameter(name="A parameter", value=NormalReal(mean=17, std=1, units=''))
     measurement = MeasurementRun(tags="A tag on a measurement", conditions=condition,
                                  parameters=parameter)
-    copy_meas = copy(measurement)
+    copy_meas = TaurusJson().copy(measurement)
     assert(copy_meas.conditions[0].value == measurement.conditions[0].value)
     assert(copy_meas.parameters[0].value == measurement.parameters[0].value)
     assert(copy_meas.uids["auto"] == measurement.uids["auto"])
@@ -62,14 +62,15 @@ def test_deserialize():
 
 def test_deserialize_extra_fields():
     """Extra JSON fields should be ignored in deserialization."""
-    json_data = '[[], {"nominal": 5, "type": "nominal_integer", "extra garbage": "foo"}]'
+    json_data = '{"context": [],' \
+                ' "object": {"nominal": 5, "type": "nominal_integer", "extra garbage": "foo"}}'
     assert(loads(json_data) == NominalInteger(nominal=5))
 
 
 def test_enumeration_serde():
     """An enumeration should get serialized as a string."""
     condition = Condition(name="A condition", notes=Origin.UNKNOWN)
-    copy_condition = copy(condition)
+    copy_condition = TaurusJson().copy(condition)
     assert copy_condition.notes == Origin.get_value(condition.notes)
 
 
@@ -95,7 +96,7 @@ def test_thin_dumps():
     meas_spec = MeasurementSpec("measurement", uids={'my_scope': '324324'})
     meas = MeasurementRun("The measurement", spec=meas_spec, material=mat)
 
-    thin_copy = MeasurementRun.build(json.loads(thin_dumps(meas)))
+    thin_copy = MeasurementRun.build(json.loads(TaurusJson().thin_dumps(meas)))
     assert isinstance(thin_copy, MeasurementRun)
     assert isinstance(thin_copy.material, LinkByUID)
     assert isinstance(thin_copy.spec, LinkByUID)
@@ -103,11 +104,11 @@ def test_thin_dumps():
 
     # Check that LinkByUID objects are correctly converted their JSON equivalent
     expected_json = '{"id": "my_id", "scope": "scope", "type": "link_by_uid"}'
-    assert thin_dumps(LinkByUID('scope', 'my_id')) == expected_json
+    assert TaurusJson().thin_dumps(LinkByUID('scope', 'my_id')) == expected_json
 
     # Check that objects lacking .uid attributes will raise an exception when dumped
     with pytest.raises(TypeError):
-        thin_dumps({{'key': 'value'}})
+        TaurusJson().thin_dumps({{'key': 'value'}})
 
 
 def test_uid_deser():
@@ -153,6 +154,37 @@ def test_unexpected_deserialization():
         dumps(ProcessRun("A process", notes=DummyClass("something")))
 
 
+def test_register_classes_override():
+    """Test that register_classes overrides existing entries in the class index."""
+    class MyProcessSpec(ProcessSpec):
+        pass
+
+    normal = TaurusJson()
+    custom = TaurusJson()
+    custom.register_classes({MyProcessSpec.typ: MyProcessSpec})
+
+    obj = ProcessSpec(name="foo")
+    assert not isinstance(normal.copy(obj), MyProcessSpec),\
+        "Class registration bled across TaurusJson() objects"
+
+    assert isinstance(custom.copy(obj), ProcessSpec),\
+        "Custom TaurusJson didn't deserialize as MyProcessSpec"
+
+
+def test_register_argument_validation():
+    """Test that register_classes argument is type checked."""
+    orig = TaurusJson()
+
+    with pytest.raises(ValueError):
+        orig.register_classes("foo")
+
+    with pytest.raises(ValueError):
+        orig.register_classes({"foo": orig})
+
+    with pytest.raises(ValueError):
+        orig.register_classes({ProcessSpec: ProcessSpec})
+
+
 def test_pure_subsitutions():
     """Make sure substitute methods don't mutate inputs."""
     json_str = '''
@@ -185,7 +217,7 @@ def test_pure_subsitutions():
           ]
        '''
     index = {}
-    original = json.loads(json_str, object_hook=lambda x: _loado(x, index))
+    original = json.loads(json_str, object_hook=lambda x: TaurusJson()._load_and_index(x, index))
     frozen = deepcopy(original)
     loaded = substitute_objects(original, index)
     assert original == frozen
@@ -210,8 +242,8 @@ def test_case_insensitive_rehydration():
     # The material link has "scope": "ID", whereas the material in the context list, which is
     # to be loaded, has uid with scope "id".
     json_str = '''
-          [
-            [
+          {
+            "context": [
               {
                 "uids": {
                   "id": "9118c2d3-1c38-47fe-a650-c2b92fdb6777"
@@ -220,7 +252,7 @@ def test_case_insensitive_rehydration():
                 "name": "flour"
               }
             ],
-            {
+            "object": {
               "type": "ingredient_run",
               "uids": {
                 "id": "8858805f-ec02-49e4-ba3b-d784e2aea3f8"
@@ -236,7 +268,7 @@ def test_case_insensitive_rehydration():
                 "id": "9148c2d3-2c38-47fe-b650-c2b92fdb6777"
               }
             }
-          ]
+          }
        '''
     loaded_ingredient = loads(json_str)
     # The ingredient's material will either be a MaterialRun (pass) or a LinkByUID (fail)
@@ -267,8 +299,8 @@ def test_deeply_nested_rehydration():
     LinkByUid before they are "declared" in the JSON array.
     """
     json_str = '''
-[
-  [
+{
+  "context": [
     {
       "type": "process_spec",
       "parameters": [
@@ -590,12 +622,12 @@ def test_deeply_nested_rehydration():
       "file_links": []
     }
   ],
-  {
+  "object": {
     "type": "link_by_uid",
     "scope": "id",
     "id": "f0f41fb9-32dc-4903-aaf4-f369de71530f"
   }
-]
+}
     '''
     material_history = loads(json_str)
     assert isinstance(material_history.process.ingredients[1].spec, IngredientSpec)

--- a/taurus/tests/test_examples.py
+++ b/taurus/tests/test_examples.py
@@ -162,4 +162,4 @@ def test_access_data():
 
     # check that the serialization results in the correct number of objects in the preface
     # (note that neither measurements nor ingredients are serialized)
-    assert(len(json.loads(dumps(island))[0]) == 26)
+    assert(len(json.loads(dumps(island))["context"]) == 26)

--- a/taurus/tests/test_examples.py
+++ b/taurus/tests/test_examples.py
@@ -4,7 +4,7 @@ import json
 from taurus.entity.object.ingredient_run import IngredientRun
 from toolz import keymap, merge, keyfilter
 
-from taurus.client.json_encoder import dumps
+from taurus.json import dumps
 from taurus.entity.attribute.condition import Condition
 from taurus.entity.attribute.parameter import Parameter
 from taurus.entity.attribute.property import Property

--- a/tox.ini
+++ b/tox.ini
@@ -17,5 +17,6 @@ ignore = D100,D104,D105,D107,D301,D401,E221
 omit =
     # omit demos
     taurus/demo/*
+    taurus/client/json_encoder.py
     # omit ingest examples
     taurus/ingest/*


### PR DESCRIPTION
This way, the class list can be manipulated safely, since there's
no global state.  A default instance is created in the taurus.json
module that's used to provide taurus.json.load and
taurus.json.dump