### PR TITLE
Include the output material when serializing processes

### DIFF
--- a/taurus/entity/base_entity.py
+++ b/taurus/entity/base_entity.py
@@ -1,6 +1,4 @@
 """Base class for all entities."""
-from typing import Iterable
-
 from taurus.entity.dict_serializable import DictSerializable
 from taurus.entity.case_insensitive_dict import CaseInsensitiveDict
 
@@ -72,14 +70,3 @@ class BaseEntity(DictSerializable):
 
         """
         self.uids[scope] = uid
-
-    @property
-    def _forward(self) -> Iterable[str]:
-        """List of forward links that should be skipped when doing a chronological traversal.
-
-        Usually, this is the same as the skip list.  However, the link direction between
-        ingredients and processes is flipped: the ingredient -> process links is the writeable one
-        while the process -> ingredient link is read-only.  This is the opposite of chronological
-        order, so _forward gives a way to express the chronological ordering as well.
-        """
-        return self.skip

--- a/taurus/entity/object/material_run.py
+++ b/taurus/entity/object/material_run.py
@@ -1,5 +1,3 @@
-from typing import Iterable
-
 from taurus.entity.object.base_object import BaseObject
 from taurus.enumeration import SampleType
 
@@ -123,14 +121,3 @@ class MaterialRun(BaseObject):
             return self.spec.template
         else:
             return None
-
-    @property
-    def _forward(self) -> Iterable[str]:
-        """List of forward links that should be skipped when doing a chronological traversal.
-
-        There are no forward links present in the material run.  The only item in skip,
-        measurements, should be included when doing a "chronological" traversal.  It just
-        shouldn't be included *as a member* when serializing the material run objects.
-        :return: an empty set
-        """
-        return {}

--- a/taurus/entity/object/process_run.py
+++ b/taurus/entity/object/process_run.py
@@ -1,5 +1,3 @@
-from typing import Iterable
-
 from taurus.entity.object.base_object import BaseObject
 from taurus.entity.object.has_conditions import HasConditions
 from taurus.entity.object.has_parameters import HasParameters
@@ -109,17 +107,3 @@ class ProcessRun(BaseObject, HasConditions, HasParameters, HasSource):
             return self.spec.template
         else:
             return None
-
-    @property
-    def _forward(self) -> Iterable[str]:
-        """List of forward links that should be skipped when doing a chronological traversal.
-
-        Usually, this is the same as the skip list.  However, the link direction between
-        ingredients and processes is flipped: the ingredient -> process links is the writeable one
-        while the process -> ingredient link is read-only.  This is the opposite of chronological
-        order, so _forward gives a way to express the chronological ordering as well.
-
-        Ingredients are _not_ forward links, even though they are skipped, so they are not included
-        below.
-        """
-        return {"_output_material"}

--- a/taurus/entity/object/process_spec.py
+++ b/taurus/entity/object/process_spec.py
@@ -1,5 +1,3 @@
-from typing import Iterable
-
 from taurus.entity.object.base_object import BaseObject
 from taurus.entity.object.has_parameters import HasParameters
 from taurus.entity.object.has_conditions import HasConditions
@@ -84,17 +82,3 @@ class ProcessSpec(BaseObject, HasParameters, HasConditions, HasTemplate):
     def output_material(self):
         """Get the output material spec."""
         return self._output_material
-
-    @property
-    def _forward(self) -> Iterable[str]:
-        """List of forward links that should be skipped when doing a chronological traversal.
-
-        Usually, this is the same as the skip list.  However, the link direction between
-        ingredients and processes is flipped: the ingredient -> process links is the writeable one
-        while the process -> ingredient link is read-only.  This is the opposite of chronological
-        order, so _forward gives a way to express the chronological ordering as well.
-
-        Ingredients are _not_ forward links, even though they are skipped, so they are not included
-        below.
-        """
-        return {"_output_material"}

--- a/taurus/entity/object/tests/test_process_spec.py
+++ b/taurus/entity/object/tests/test_process_spec.py
@@ -40,10 +40,10 @@ def test_material_spec():
     mat_spec_copy = loads(dumps(mat_spec))
     proc_spec_copy = loads(dumps(proc_spec))
 
-    assert proc_spec_copy.output_material is None, \
+    assert proc_spec_copy.output_material == mat_spec, \
         "Serialization should break link from ProcessSpec to MaterialSpec"
 
-    assert dumps(mat_spec_copy.process) == dumps(proc_spec), \
+    assert mat_spec_copy.process == proc_spec, \
         "Serialization should preserve link from MaterialSpec to ProcessSpec"
 
 

--- a/taurus/util/tests/test_flatten.py
+++ b/taurus/util/tests/test_flatten.py
@@ -31,23 +31,22 @@ def test_flatten_empty_history():
     transform_run = ProcessRun(name="transformed", spec=transform)
     ingredient_run = IngredientRun(material=input_run, process=transform_run, spec=ingredient)
 
-    assert len(flatten(procured)) == 0
+    assert len(flatten(procured)) == 1
     assert len(flatten(input)) == 1
     assert len(flatten(ingredient)) == 3
     assert len(flatten(transform)) == 3
 
-    assert len(flatten(procured_run)) == 1
+    assert len(flatten(procured_run)) == 3
     assert len(flatten(input_run)) == 3
     assert len(flatten(ingredient_run)) == 7
     assert len(flatten(transform_run)) == 7
 
 
-def test_flatmap_skip_ordering():
-    """Test that the chronological setting is obeyed."""
-    # The writeable link is ingredient -> process, but the chronological link is
-    # process -> ingredient
+def test_flatmap_unidirectional_ordering():
+    """Test that the unidirecitonal setting is obeyed."""
+    # The writeable link is ingredient -> process, not process -> ingredients
     proc = ProcessRun(name="foo")
     IngredientRun(notes="bar", process=proc)
 
-    assert len(recursive_flatmap(proc, lambda x: [x], chronological=True)) == 2
-    assert len(recursive_flatmap(proc, lambda x: [x], chronological=False)) == 0
+    assert len(recursive_flatmap(proc, lambda x: [x], unidirectional=False)) == 2
+    assert len(recursive_flatmap(proc, lambda x: [x], unidirectional=True)) == 0


### PR DESCRIPTION
This acknolwedges that (process, output_material) are two halves
of the same chronological entity.  As a positive side-effect,
this means that every object that is accessible via the
python attributes of the objects is included in serialization,
which removes the need for the _forward option and simplifies the code.

To reflect the singular purpose of skip, the option in recursive_flatmap
has been renamed to "unidirectional": only the writable half of
bidirectional links are traversed when unidirection is True.