### PR TITLE
Add package imports to __init__.py's

### DIFF
--- a/taurus/demo/cake.py
+++ b/taurus/demo/cake.py
@@ -3,38 +3,18 @@ import json
 
 import random
 
-from taurus.entity.attribute.condition import Condition
-from taurus.entity.attribute.parameter import Parameter
-from taurus.entity.attribute.property import Property
-from taurus.entity.attribute.property_and_conditions import PropertyAndConditions
-from taurus.entity.bounds.integer_bounds import IntegerBounds
-from taurus.entity.bounds.real_bounds import RealBounds
-from taurus.entity.bounds.categorical_bounds import CategoricalBounds
-from taurus.entity.bounds.composition_bounds import CompositionBounds
-from taurus.entity.object.ingredient_run import IngredientRun
-from taurus.entity.object.ingredient_spec import IngredientSpec
-from taurus.entity.object.material_run import MaterialRun
-from taurus.entity.object.material_spec import MaterialSpec
-from taurus.entity.object.measurement_run import MeasurementRun
-from taurus.entity.object.measurement_spec import MeasurementSpec
-from taurus.entity.object.process_run import ProcessRun
-from taurus.entity.object.process_spec import ProcessSpec
-from taurus.entity.template.condition_template import ConditionTemplate
-from taurus.entity.template.material_template import MaterialTemplate
-from taurus.entity.template.measurement_template import MeasurementTemplate
-from taurus.entity.template.parameter_template import ParameterTemplate
-from taurus.entity.template.process_template import ProcessTemplate
-from taurus.entity.template.property_template import PropertyTemplate
-from taurus.entity.value.nominal_integer import NominalInteger
-from taurus.entity.value.uniform_integer import UniformInteger
-from taurus.entity.value.nominal_real import NominalReal
-from taurus.entity.value.normal_real import NormalReal
-from taurus.entity.value.uniform_real import UniformReal
-from taurus.entity.value.nominal_categorical import NominalCategorical
-from taurus.entity.value.discrete_categorical import DiscreteCategorical
-from taurus.entity.value.nominal_composition import NominalComposition
-from taurus.entity.value.empirical_formula import EmpiricalFormula
+from taurus.entity.attribute import Condition, Parameter, Property, PropertyAndConditions
+from taurus.entity.bounds import IntegerBounds, RealBounds, CategoricalBounds, CompositionBounds
+from taurus.entity.object import ProcessSpec, ProcessRun, MaterialSpec, MaterialRun, \
+    MeasurementSpec, MeasurementRun, IngredientSpec, IngredientRun
+from taurus.entity.template import ProcessTemplate, MaterialTemplate, MeasurementTemplate, \
+    PropertyTemplate, ParameterTemplate, ConditionTemplate
+from taurus.entity.value import NominalInteger, UniformInteger, \
+    NominalReal, NormalReal, UniformReal, \
+    NominalCategorical, DiscreteCategorical, \
+    NominalComposition, EmpiricalFormula
 from taurus.enumeration.origin import Origin
+
 from taurus.entity.util import complete_material_history, make_instance
 from taurus.entity.file_link import FileLink
 from taurus.entity.source.performed_source import PerformedSource

--- a/taurus/entity/attribute/__init__.py
+++ b/taurus/entity/attribute/__init__.py
@@ -1,1 +1,6 @@
 """Attribute objects."""
+# flake8: noqa
+from .condition import Condition
+from .parameter import Parameter
+from .property import Property
+from .property_and_conditions import PropertyAndConditions

--- a/taurus/entity/bounds/__init__.py
+++ b/taurus/entity/bounds/__init__.py
@@ -1,1 +1,6 @@
 """Bounds on a value."""
+# flake8: noqa
+from .categorical_bounds import CategoricalBounds
+from .composition_bounds import CompositionBounds
+from .integer_bounds import IntegerBounds
+from .real_bounds import RealBounds

--- a/taurus/entity/object/__init__.py
+++ b/taurus/entity/object/__init__.py
@@ -1,3 +1,4 @@
+"""Run and Spec Objects"""
 # flake8: noqa
 from .material_run import MaterialRun
 from .measurement_run import MeasurementRun

--- a/taurus/entity/template/__init__.py
+++ b/taurus/entity/template/__init__.py
@@ -1,1 +1,8 @@
+"""Attribute and Object Templates"""
 # flake8: noqa
+from .property_template import PropertyTemplate
+from .condition_template import ConditionTemplate
+from .parameter_template import ParameterTemplate
+from .material_template import MaterialTemplate
+from .measurement_template import MeasurementTemplate
+from .process_template import ProcessTemplate

--- a/taurus/entity/value/__init__.py
+++ b/taurus/entity/value/__init__.py
@@ -1,1 +1,11 @@
+"""Value objects"""
 # flake8: noqa
+from .nominal_real import NominalReal
+from .normal_real import NormalReal
+from .uniform_real import UniformReal
+from .nominal_integer import NominalInteger
+from .uniform_integer import UniformInteger
+from .discrete_categorical import DiscreteCategorical
+from .nominal_categorical import NominalCategorical
+from .empirical_formula import EmpiricalFormula
+from .nominal_composition import NominalComposition

--- a/taurus/util/__init__.py
+++ b/taurus/util/__init__.py
@@ -1,2 +1,3 @@
 # flake8: noqa
-from .impl import *
+from .impl import set_uuids, substitute_links, substitute_objects, flatten, recursive_foreach, \
+    recursive_flatmap, writable_sort_order

--- a/taurus/util/impl.py
+++ b/taurus/util/impl.py
@@ -7,15 +7,6 @@ from taurus.entity.dict_serializable import DictSerializable
 from taurus.entity.link_by_uid import LinkByUID
 from toolz import concatv
 
-from taurus.entity.object import MeasurementSpec, ProcessSpec, MaterialSpec, IngredientSpec, \
-    MeasurementRun, IngredientRun, MaterialRun, ProcessRun
-from taurus.entity.template.condition_template import ConditionTemplate
-from taurus.entity.template.material_template import MaterialTemplate
-from taurus.entity.template.measurement_template import MeasurementTemplate
-from taurus.entity.template.parameter_template import ParameterTemplate
-from taurus.entity.template.process_template import ProcessTemplate
-from taurus.entity.template.property_template import PropertyTemplate
-
 
 def set_uuids(obj, name="auto"):
     """
@@ -248,6 +239,11 @@ def recursive_flatmap(obj, func, seen=None, unidirectional=True):
 
 def writable_sort_order(key: Union[BaseEntity, str]) -> int:
     """Sort order for flattening such that the objects can be read back and re-nested."""
+    from taurus.entity.object import MeasurementSpec, ProcessSpec, MaterialSpec, IngredientSpec, \
+        MeasurementRun, IngredientRun, MaterialRun, ProcessRun
+    from taurus.entity.template import ConditionTemplate, MaterialTemplate, MeasurementTemplate, \
+        ParameterTemplate, ProcessTemplate, PropertyTemplate
+
     if isinstance(key, BaseEntity):
         typ = key.typ
     elif isinstance(key, str):


### PR DESCRIPTION
Added consistency of structure across __init__.py files so that objects that are regularly imported en-mass are clustered.  

This also identified a barely-avoided circular reference, and made the associated imports more naturally distributed.

Cake was modified to use the new formulation to maintain test coverage.