### PR TITLE
Adpated S&C demo to named instead of indexed json structure

### DIFF
--- a/taurus/demo/strehlow_and_cook.py
+++ b/taurus/demo/strehlow_and_cook.py
@@ -465,7 +465,7 @@ if __name__ == "__main__":
 
     print("\n\nJSON -- Training table")
     import taurus.json as je
-    print(json.dumps(json.loads(je.dumps(full_table))[1], indent=2))
+    print(json.dumps(json.loads(je.dumps(full_table))["object"], indent=2))
 
     print("\n\nCSV -- Display table")
     display = make_display_table(full_table)

--- a/taurus/demo/tests/test_sac.py
+++ b/taurus/demo/tests/test_sac.py
@@ -2,6 +2,7 @@
 from taurus.demo.strehlow_and_cook import make_strehlow_table, make_strehlow_objects, \
     minimal_subset, import_table
 import taurus.json as je
+import json
 
 
 def test_sac():
@@ -21,3 +22,6 @@ def test_sac():
     # Make sure there's no migration with repeated serialization
     for row in sac_tbl:
         assert je.dumps(je.loads(je.dumps(row))) == je.dumps(row)
+
+    # Verify that the serialization trick for mocking a structured table works
+    json.dumps(json.loads(je.dumps(sac_tbl))["object"], indent=2)


### PR DESCRIPTION
The shift from array to dictionary representation broke some code in the name==main block of the Strehlow and Cook example.  This corrects that issue and adds a test to catch if a migration will cause a similar problem.  

It's still a mock that needs to be verified against actual structured data output, probably as a regression test.